### PR TITLE
docs abstraction & code formating 

### DIFF
--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -28,7 +28,6 @@ jobs:
       uses: actions/checkout@v2
     - name: overwrite doxygen tags
       run: |
-        mkdir docs
         touch doxygenAction
         echo "PROJECT_NUMBER = ${{ steps.latest_ver.outputs.release }}" >> doxygenAction
         echo "@INCLUDE = doxygenAction" >> Doxyfile

--- a/.gitignore
+++ b/.gitignore
@@ -44,4 +44,5 @@ Temporary Items
 .apdisk
 
 # ignore docs folder
-docs/
+docs/html/
+docs/xml/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+These are the current requirements for getting your code included in RF24:
+
+* Try your best to follow the rest of the code, if you're unsure then the NASA C style can help as it's closest to the current style: https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19950022400.pdf
+
+* Definetly follow [PEP-8](https://www.python.org/dev/peps/pep-0008/) if it's Python code.
+
+* Follow the [Arduino IDE formatting style](https://www.arduino.cc/en/Reference/StyleGuide) for Arduino examples
+
+* Add [doxygen-compatible documentation](https://www.doxygen.nl/manual/docblocks.html) to any new functions you add, or update existing documentation if you change behaviour

--- a/Dns.cpp
+++ b/Dns.cpp
@@ -4,9 +4,7 @@
 
 #include "RF24Ethernet.h"
 
-
 #if UIP_CONF_UDP > 0
-
 
 #define SOCKET_NONE	255
 // Various flags and header field values for a DNS message
@@ -128,13 +126,13 @@ int DNSClient::getHostByName(const char* aHostname, IPAddress& aResult)
 	    IF_RF24ETHERNET_DEBUG_DNS( Serial.println(F("RF24DNS Invalid DNS Server")) );
         return INVALID_SERVER;
     }
-	
+
     // Find a socket to use
     if (iUdp.begin(1024+(millis() & 0xF)) == 1)
     {
         // Try up to three times
         int retries = 0;
-//        while ((retries < 3) && (ret <= 0))
+        // while ((retries < 3) && (ret <= 0))
         {
             // Send DNS request
             ret = iUdp.beginPacket(iDNSServer, DNS_PORT);
@@ -258,7 +256,7 @@ uint16_t DNSClient::ProcessResponse(uint16_t aTimeout, IPAddress& aAddress)
     {
         if((millis() - startTime) > aTimeout){
             IF_RF24ETHERNET_DEBUG_DNS( Serial.println(F("RF24 DNS - Request timed out")); );
-			return TIMED_OUT;			
+			return TIMED_OUT;
 		}
         //delay(50);
     }
@@ -267,7 +265,7 @@ uint16_t DNSClient::ProcessResponse(uint16_t aTimeout, IPAddress& aAddress)
     // Read the UDP header
     uint8_t header[DNS_HEADER_SIZE]; // Enough space to reuse for the DNS header
     // Check that it's a response from the right server and the right port
-    if ( (iDNSServer != iUdp.remoteIP()) || 
+    if ( (iDNSServer != iUdp.remoteIP()) ||
         (iUdp.remotePort() != DNS_PORT) )
     {
         // It's not from who we expected
@@ -283,7 +281,7 @@ uint16_t DNSClient::ProcessResponse(uint16_t aTimeout, IPAddress& aAddress)
     }
 	IF_RF24ETHERNET_DEBUG_DNS( Serial.print(F("RF24DNS - DNS Header Size: ")); Serial.println(DNS_HEADER_SIZE); );
     iUdp.read(header, DNS_HEADER_SIZE);
-    
+
     uint16_t header_flags = htons(*((uint16_t*)&header[2]));
     // Check that it's a response to this request
     if ( ( iRequestId != (*((uint16_t*)&header[0])) ) ||
@@ -315,7 +313,7 @@ uint16_t DNSClient::ProcessResponse(uint16_t aTimeout, IPAddress& aAddress)
     }
 
 	IF_RF24ETHERNET_DEBUG_DNS( Serial.print(F("RF24DNS OK, skipping questions ")); Serial.println(header[5]); );
-	
+
     // Skip over any questions
     for (uint16_t i =0; i < HTONS(*((uint16_t*)&header[4])); i++)
 //	for (uint16_t i =0; i < wtf; i++)

--- a/Dns.h
+++ b/Dns.h
@@ -9,27 +9,28 @@
 
 #if UIP_CONF_UDP > 0
 
-
 class DNSClient
 {
 public:
 
     void begin(const IPAddress& aDNSServer);
 
-    /** Convert a numeric IP address string into a four-byte IP address.
-        @param aIPAddrString IP address to convert
-        @param aResult IPAddress structure to store the returned IP address
-        @result 1 if aIPAddrString was successfully converted to an IP address,
-                else error code
-    */
+    /**
+     * Convert a numeric IP address string into a four-byte IP address.
+     * @param aIPAddrString IP address to convert
+     * @param aResult IPAddress structure to store the returned IP address
+     * @result 1 if aIPAddrString was successfully converted to an IP address,
+     * else error code
+     */
     int inet_aton(const char *aIPAddrString, IPAddress& aResult);
 
-    /** Resolve the given hostname to an IP address.
-        @param aHostname Name to be resolved
-        @param aResult IPAddress structure to store the returned IP address
-        @result 1 if aIPAddrString was successfully converted to an IP address,
-                else error code
-    */
+    /**
+     * Resolve the given hostname to an IP address.
+     * @param aHostname Name to be resolved
+     * @param aResult IPAddress structure to store the returned IP address
+     * @result 1 if aIPAddrString was successfully converted to an IP address,
+     * else error code
+     */
     int getHostByName(const char* aHostname, IPAddress& aResult);
 
 protected:

--- a/Doxyfile
+++ b/Doxyfile
@@ -829,7 +829,8 @@ INPUT                  = ./ \
                          ./examples/InteractiveServer_Mesh/HTML.h \
                          ./examples/InteractiveServer_Mesh_ESPWifi/HTML.h \
                          ./examples/SLIP_InteractiveServer/HTML.h \
-                         ./examples/TAP/InteractiveServer/HTML.h
+                         ./examples/TAP/InteractiveServer/HTML.h \
+                         ./docs
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses
@@ -942,7 +943,8 @@ EXCLUDE_PATTERNS       =
 
 EXCLUDE_SYMBOLS        = IP_ADDR* \
                          uip_userdata_* \
-                         uip_udp_userdata_*
+                         uip_udp_userdata_* \
+                         docs/README.md
 
 # The EXAMPLE_PATH tag can be used to specify one or more files or directories
 # that contain example code fragments that are included (see the \include
@@ -1024,7 +1026,7 @@ FILTER_SOURCE_PATTERNS =
 # (index.html). This can be useful if you have a project on for instance GitHub
 # and want to reuse the introduction page also for the doxygen output.
 
-USE_MDFILE_AS_MAINPAGE =
+USE_MDFILE_AS_MAINPAGE = ./docs/main_page.md
 
 #---------------------------------------------------------------------------
 # Configuration options related to source browsing
@@ -2584,4 +2586,3 @@ GENERATE_LEGEND        = YES
 # This tag requires that the tag HAVE_DOT is set to YES.
 
 DOT_CLEANUP            = YES
-

--- a/RF24Client.cpp
+++ b/RF24Client.cpp
@@ -1,6 +1,6 @@
 /*
  RF24Client.cpp - Arduino implementation of a uIP wrapper class.
- Copyright (c) 2014 tmrh20@gmail.com, github.com/TMRh20 
+ Copyright (c) 2014 tmrh20@gmail.com, github.com/TMRh20
  Copyright (c) 2013 Norbert Truchsess <norbert.truchsess@t-online.de>
  All rights reserved.
  This program is free software: you can redistribute it and/or modify
@@ -16,478 +16,536 @@
   */
 #include "RF24Ethernet.h"
 
-#define UIP_TCP_PHYH_LEN UIP_LLH_LEN+UIP_IPTCPH_LEN
+#define UIP_TCP_PHYH_LEN UIP_LLH_LEN + UIP_IPTCPH_LEN
 
 uip_userdata_t RF24Client::all_data[UIP_CONNS];
 
+/*************************************************************/
+
+RF24Client::RF24Client() : data(NULL) {}
 
 /*************************************************************/
 
-RF24Client::RF24Client(): data(NULL){
+RF24Client::RF24Client(uip_userdata_t *conn_data) : data(conn_data) {}
+
+/*************************************************************/
+
+uint8_t RF24Client::connected()
+{
+    return (data && (data->packets_in != 0 || (data->state & UIP_CLIENT_CONNECTED))) ? 1 : 0;
 }
 
 /*************************************************************/
 
-RF24Client::RF24Client(uip_userdata_t* conn_data) :  data(conn_data){
-}
-
-/*************************************************************/
-
-uint8_t RF24Client::connected(){
-  return (data && (data->packets_in != 0 || (data->state & UIP_CLIENT_CONNECTED))) ? 1 : 0;
-}
-
-/*************************************************************/
-
-int RF24Client::connect(IPAddress ip, uint16_t port) {
-
+int RF24Client::connect(IPAddress ip, uint16_t port)
+{
 #if UIP_ACTIVE_OPEN > 0
- 
-//do{
 
-  stop();
-  uip_ipaddr_t ipaddr;
-  uip_ip_addr(ipaddr, ip);
+    //do{
 
-  struct uip_conn* conn = uip_connect(&ipaddr, htons(port));
+    stop();
+    uip_ipaddr_t ipaddr;
+    uip_ip_addr(ipaddr, ip);
 
-  if (conn){
+    struct uip_conn *conn = uip_connect(&ipaddr, htons(port));
 
-	#if UIP_CONNECTION_TIMEOUT > 0
-    uint32_t timeout = millis();
+    if (conn)
+    {
+    #if UIP_CONNECTION_TIMEOUT > 0
+        uint32_t timeout = millis();
     #endif
 
-    while((conn->tcpstateflags & UIP_TS_MASK) != UIP_CLOSED) {
-      RF24EthernetClass::tick();
-	
-	  if ((conn->tcpstateflags & UIP_TS_MASK) == UIP_ESTABLISHED) {
-	    data = (uip_userdata_t*) conn->appstate;
-	    IF_RF24ETHERNET_DEBUG_CLIENT( Serial.print(millis()); Serial.print(F(" connected, state: ")); Serial.print(data->state); Serial.print(F(", first packet in: ")); Serial.println(data->packets_in);  );
-	    return 1;
-	  }	  
-	
-	#if UIP_CONNECTION_TIMEOUT > 0
-	  if( (millis()- timeout) > UIP_CONNECTION_TIMEOUT) {
-	    conn->tcpstateflags = UIP_CLOSED;
-	    break;
-	  }
-    
-	#endif
-	}
-  }
-  //delay(25);
-//}while(millis()-timer < 175);
+        while ((conn->tcpstateflags & UIP_TS_MASK) != UIP_CLOSED)
+        {
+            RF24EthernetClass::tick();
+
+            if ((conn->tcpstateflags & UIP_TS_MASK) == UIP_ESTABLISHED)
+            {
+                data = (uip_userdata_t *)conn->appstate;
+                IF_RF24ETHERNET_DEBUG_CLIENT(Serial.print(millis()); Serial.print(F(" connected, state: ")); Serial.print(data->state); Serial.print(F(", first packet in: ")); Serial.println(data->packets_in););
+                return 1;
+            }
+
+    #if UIP_CONNECTION_TIMEOUT > 0
+            if ((millis() - timeout) > UIP_CONNECTION_TIMEOUT)
+            {
+                conn->tcpstateflags = UIP_CLOSED;
+                break;
+            }
+    #endif
+
+        }
+    }
+    //delay(25);
+    //}while(millis()-timer < 175);
 
 #endif //Active open enabled
 
-return 0;
+    return 0;
 }
 
 /*************************************************************/
 
-int RF24Client::connect(const char *host, uint16_t port) {
-  // Look up the host first
-  int ret = 0;
+int RF24Client::connect(const char *host, uint16_t port)
+{
+    // Look up the host first
+    int ret = 0;
 
-  #if UIP_UDP
-  DNSClient dns;
-  IPAddress remote_addr;
+#if UIP_UDP
+    DNSClient dns;
+    IPAddress remote_addr;
 
-  dns.begin(RF24EthernetClass::_dnsServerAddress);
-  ret = dns.getHostByName(host, remote_addr);
-  
-  if (ret == 1) {
-    #if defined (ETH_DEBUG_L1) || #defined (RF24ETHERNET_DEBUG_DNS)
-	  Serial.println(F("*UIP Got DNS*"));
-	#endif
-    return connect(remote_addr, port);
-  }
-  #else
-    if(host){}; //Do something with the input paramaters to prevent compile time warnings
-    if(port){};
-  #endif
-  
-  
-  #if defined (ETH_DEBUG_L1) || defined (RF24ETHERNET_DEBUG_DNS)
-    Serial.println(F("*UIP DNS fail*"));
-  #endif
+    dns.begin(RF24EthernetClass::_dnsServerAddress);
+    ret = dns.getHostByName(host, remote_addr);
 
-  return ret;
-}
-
-/*************************************************************/
-
-void RF24Client::stop() {
-
-  if (data && data->state) {
-      
-	IF_RF24ETHERNET_DEBUG_CLIENT( Serial.print(millis()); Serial.println(F(" before stop(), with data")); );
-      
-	data->packets_in = 0;
-	data->dataCnt = 0;
-	  
-    if (data->state & UIP_CLIENT_REMOTECLOSED){
-      data->state = 0;
-    }else{
-      data->state |= UIP_CLIENT_CLOSE;
+    if (ret == 1)
+    {
+    #if defined(ETH_DEBUG_L1) || #defined(RF24ETHERNET_DEBUG_DNS)
+        Serial.println(F("*UIP Got DNS*"));
+    #endif
+        return connect(remote_addr, port);
     }
-	  
-	IF_RF24ETHERNET_DEBUG_CLIENT( Serial.println(F("after stop()")); );
-    
-  }else{
-    IF_RF24ETHERNET_DEBUG_CLIENT( Serial.print(millis()); Serial.println(F(" stop(), data: NULL")); );
-  }
-	
-  data = NULL;
-  RF24Ethernet.tick();
+#else // ! UIP_UDP
+    //Do something with the input paramaters to prevent compile time warnings
+    if (host) {};
+    if (port) {};
+#endif // ! UIP_UDP
+
+#if defined(ETH_DEBUG_L1) || defined(RF24ETHERNET_DEBUG_DNS)
+    Serial.println(F("*UIP DNS fail*"));
+#endif
+
+    return ret;
+}
+
+/*************************************************************/
+
+void RF24Client::stop()
+{
+    if (data && data->state)
+    {
+
+        IF_RF24ETHERNET_DEBUG_CLIENT(Serial.print(millis()); Serial.println(F(" before stop(), with data")););
+
+        data->packets_in = 0;
+        data->dataCnt = 0;
+
+        if (data->state & UIP_CLIENT_REMOTECLOSED)
+        {
+            data->state = 0;
+        }
+        else
+        {
+            data->state |= UIP_CLIENT_CLOSE;
+        }
+
+        IF_RF24ETHERNET_DEBUG_CLIENT(Serial.println(F("after stop()")););
+    }
+    else
+    {
+        IF_RF24ETHERNET_DEBUG_CLIENT(Serial.print(millis()); Serial.println(F(" stop(), data: NULL")););
+    }
+
+    data = NULL;
+    RF24Ethernet.tick();
 }
 
 /*************************************************************/
 
 // the next function allows us to use the client returned by
 // EthernetServer::available() as the condition in an if-statement.
-bool RF24Client::operator==(const RF24Client& rhs) {
-  return data && rhs.data && (data == rhs.data);
+bool RF24Client::operator==(const RF24Client &rhs)
+{
+    return data && rhs.data && (data == rhs.data);
 }
 
 /*************************************************************/
 
-RF24Client::operator bool() {
-  Ethernet.tick();
-  return data && (!(data->state & UIP_CLIENT_REMOTECLOSED) || data->packets_in != 0);
+RF24Client::operator bool()
+{
+    Ethernet.tick();
+    return data && (!(data->state & UIP_CLIENT_REMOTECLOSED) || data->packets_in != 0);
 }
 
 /*************************************************************/
 
-size_t RF24Client::write(uint8_t c) {
-  return _write(data, &c, 1);
+size_t RF24Client::write(uint8_t c)
+{
+    return _write(data, &c, 1);
 }
 
 /*************************************************************/
 
-size_t RF24Client::write(const uint8_t *buf, size_t size) {
-  return _write(data, buf, size);
+size_t RF24Client::write(const uint8_t *buf, size_t size)
+{
+    return _write(data, buf, size);
 }
 
 /*************************************************************/
 
-size_t RF24Client::_write(uip_userdata_t* u, const uint8_t *buf, size_t size) {
+size_t RF24Client::_write(uip_userdata_t *u, const uint8_t *buf, size_t size)
+{
 
-  size_t total_written = 0;
-  size_t payloadSize = rf24_min(size,UIP_TCP_MSS);
-  
-test2:    
+    size_t total_written = 0;
+    size_t payloadSize = rf24_min(size, UIP_TCP_MSS);
 
-  RF24EthernetClass::tick(); 	
-  if (u && !(u->state & (UIP_CLIENT_CLOSE | UIP_CLIENT_REMOTECLOSED ) ) && u->state & (UIP_CLIENT_CONNECTED) ) {
+test2:
 
-    if( u->out_pos + payloadSize > UIP_TCP_MSS || u->hold){
-	  goto test2;
+    RF24EthernetClass::tick();
+    if (u && !(u->state & (UIP_CLIENT_CLOSE | UIP_CLIENT_REMOTECLOSED)) && u->state & (UIP_CLIENT_CONNECTED))
+    {
+
+        if (u->out_pos + payloadSize > UIP_TCP_MSS || u->hold)
+        {
+            goto test2;
+        }
+
+        IF_RF24ETHERNET_DEBUG_CLIENT(Serial.println(); Serial.print(millis()); Serial.print(F(" UIPClient.write: writePacket(")); Serial.print(u->packets_out); Serial.print(F(") pos: ")); Serial.print(u->out_pos); Serial.print(F(", buf[")); Serial.print(size - total_written); Serial.print(F("]: '")); Serial.write((uint8_t *)buf + total_written, payloadSize); Serial.println(F("'")););
+
+        memcpy(u->myData + u->out_pos, buf + total_written, payloadSize);
+        u->packets_out = 1;
+        u->out_pos += payloadSize;
+
+        total_written += payloadSize;
+
+        if (total_written < size)
+        {
+            size_t remain = size - total_written;
+            payloadSize = rf24_min(remain, UIP_TCP_MSS);
+
+            //RF24EthernetClass::tick();
+            goto test2;
+        }
+        return u->out_pos;
+    }
+    u->hold = false;
+    return -1;
+}
+
+/*************************************************************/
+
+void uip_log(char *msg)
+{
+    //Serial.println();
+    //Serial.println("** UIP LOG **");
+    //Serial.println(msg);
+    if (msg)
+    {
+    };
+}
+
+/*************************************************************/
+
+void serialip_appcall(void)
+{
+    uip_userdata_t *u = (uip_userdata_t *)uip_conn->appstate;
+
+    /*******Connected**********/
+    if (!u && uip_connected())
+    {
+        IF_RF24ETHERNET_DEBUG_CLIENT(Serial.println(); Serial.print(millis()); Serial.println(F(" UIPClient uip_connected")););
+
+        u = (uip_userdata_t *)EthernetClient::_allocateData();
+
+        if (u)
+        {
+            uip_conn->appstate = u;
+            IF_RF24ETHERNET_DEBUG_CLIENT(Serial.print(F("UIPClient allocated state: ")); Serial.println(u->state, BIN););
+        }
+        else
+        {
+            IF_RF24ETHERNET_DEBUG_CLIENT(Serial.println(F("UIPClient allocation failed")););
+        }
     }
 
-	IF_RF24ETHERNET_DEBUG_CLIENT( Serial.println(); Serial.print(millis()); Serial.print(F(" UIPClient.write: writePacket(")); Serial.print(u->packets_out); Serial.print(F(") pos: ")); Serial.print(u->out_pos); Serial.print(F(", buf[")); Serial.print(size-total_written); Serial.print(F("]: '")); Serial.write((uint8_t*)buf+total_written,payloadSize); Serial.println(F("'")); );
-	
-	memcpy(u->myData+u->out_pos,buf+total_written,payloadSize);	
-	u->packets_out = 1;
-	u->out_pos+=payloadSize;
+    /*******User Data RX**********/
+    if (u)
+    {
+        if (uip_newdata())
+        {
+            IF_RF24ETHERNET_DEBUG_CLIENT(Serial.println(); Serial.print(millis()); Serial.print(F(" UIPClient uip_newdata, uip_len:")); Serial.println(uip_len););
 
-	total_written += payloadSize;
-	
-	if( total_written < size ){	
-		size_t remain = size-total_written;
-		payloadSize = rf24_min(remain,UIP_TCP_MSS);
-		
-		//RF24EthernetClass::tick();
-		goto test2;
-	}
-	return u->out_pos;
-	}
-  u->hold = false;
-  return -1;
-}
+            if (u->sent)
+            {
+                u->hold = (u->out_pos = (u->windowOpened = (u->packets_out = false)));
+            }
+            if (uip_len && !(u->state & (UIP_CLIENT_CLOSE | UIP_CLIENT_REMOTECLOSED)))
+            {
+                uip_stop();
+                u->state &= ~UIP_CLIENT_RESTART;
+                u->windowOpened = false;
+                u->connAbortTime = u->restartTime = millis();
+                memcpy(&u->myDataIn[u->dataPos + u->dataCnt], uip_appdata, uip_datalen());
+                u->dataCnt += uip_datalen();
 
-/*************************************************************/
+                u->packets_in = 1;
+            }
+            goto finish;
+        }
 
-void uip_log( char* msg ){
-	//Serial.println();
-	//Serial.println("** UIP LOG **");
-	//Serial.println(msg);
-    if(msg){};
-}
+        /*******Closed/Timed-out/Aborted**********/
+        // If the connection has been closed, save received but unread data.
+        if (uip_closed() || uip_timedout() || uip_aborted())
+        {
+            IF_RF24ETHERNET_DEBUG_CLIENT(Serial.println(); Serial.print(millis()); Serial.println(F(" UIPClient uip_closed")););
+            // drop outgoing packets not sent yet:
+            u->packets_out = 0;
 
-/*************************************************************/
+            if (u->packets_in)
+            {
+                ((uip_userdata_closed_t *)u)->lport = uip_conn->lport;
+                u->state |= UIP_CLIENT_REMOTECLOSED;
+                IF_RF24ETHERNET_DEBUG_CLIENT(Serial.println(F("UIPClient close 1")););
+            }
+            else
+            {
+                IF_RF24ETHERNET_DEBUG_CLIENT(Serial.println(F("UIPClient close 2")););
+                u->state = 0;
+            }
 
-void serialip_appcall(void) {
-  
-  uip_userdata_t *u = (uip_userdata_t*)uip_conn->appstate;
-  
-  /*******Connected**********/
-  if (!u && uip_connected()){
-  
-	IF_RF24ETHERNET_DEBUG_CLIENT( Serial.println(); Serial.print(millis()); Serial.println(F(" UIPClient uip_connected")); );
+            IF_RF24ETHERNET_DEBUG_CLIENT(Serial.println(F("after UIPClient uip_closed")););
+            uip_conn->appstate = NULL;
+            goto finish;
+        }
 
-    u = (uip_userdata_t*) EthernetClient::_allocateData();
-    
-	if (u) {
-      uip_conn->appstate = u;
-      IF_RF24ETHERNET_DEBUG_CLIENT( Serial.print(F("UIPClient allocated state: ")); Serial.println(u->state,BIN); );
-    }else{
-      IF_RF24ETHERNET_DEBUG_CLIENT(Serial.println(F("UIPClient allocation failed")); );
-	}
-  }
-  
-  /*******User Data RX**********/
-  if(u){
-    if (uip_newdata()){
-      IF_RF24ETHERNET_DEBUG_CLIENT( Serial.println(); Serial.print(millis()); Serial.print(F(" UIPClient uip_newdata, uip_len:")); Serial.println(uip_len); );
-      
-      if(u->sent){
-          u->hold = (u->out_pos = (u->windowOpened = (u->packets_out = false)));
-      }
-	  if (uip_len && !(u->state & (UIP_CLIENT_CLOSE | UIP_CLIENT_REMOTECLOSED))){
-		  
-		uip_stop();
-		u->state &= ~UIP_CLIENT_RESTART;
-		u->windowOpened = false;			
-		u->connAbortTime = u->restartTime = millis();
-	    memcpy(&u->myDataIn[u->dataPos+u->dataCnt], uip_appdata, uip_datalen());
-	    u->dataCnt += uip_datalen();
-		
-	    u->packets_in = 1;
-		  
-	  }		  
-	  goto finish;
-	}
+        /*******ACKED**********/
+        if (uip_acked())
+        {
+            IF_RF24ETHERNET_DEBUG_CLIENT(Serial.println(); Serial.print(millis()); Serial.println(F(" UIPClient uip_acked")););
+            u->state &= ~UIP_CLIENT_RESTART;
+            u->hold = (u->out_pos = (u->windowOpened = (u->packets_out = false)));
+            u->connAbortTime = (u->restartTime = millis());
+        }
 
-  /*******Closed/Timed-out/Aborted**********/  
-  // If the connection has been closed, save received but unread data.
-  if (uip_closed() || uip_timedout() || uip_aborted()) {
-    
-	IF_RF24ETHERNET_DEBUG_CLIENT( Serial.println();Serial.print(millis()); Serial.println(F(" UIPClient uip_closed")); );
-	// drop outgoing packets not sent yet:
-	u->packets_out = 0;
-    
-	if (u->packets_in) {
-	  ((uip_userdata_closed_t *)u)->lport = uip_conn->lport;
-	  u->state |= UIP_CLIENT_REMOTECLOSED;
-	  IF_RF24ETHERNET_DEBUG_CLIENT( Serial.println(F("UIPClient close 1")); );
-	}else{
-	  IF_RF24ETHERNET_DEBUG_CLIENT( Serial.println(F("UIPClient close 2")); );
-	  u->state = 0;
-	}
+        /*******Polling**********/
+        if (uip_poll() || uip_rexmit())
+        {
+            //IF_RF24ETHERNET_DEBUG_CLIENT( Serial.println(); Serial.println(F("UIPClient uip_poll")); );
 
-	IF_RF24ETHERNET_DEBUG_CLIENT( Serial.println(F("after UIPClient uip_closed")); );
-	uip_conn->appstate = NULL;	
-	goto finish;
-  }
+            if (u->packets_out != 0)
+            {
+                uip_len = u->out_pos;
+                uip_send(u->myData, u->out_pos);
+                u->hold = true;
+                u->sent = true;
+                goto finish;
+            }
+            else
+                // Restart mechanism to keep connections going
+                // Only call this if the TCP window has already been re-opened, the connection is being polled, but no data
+                // has been acked
+                if (!(u->state & (UIP_CLIENT_CLOSE | UIP_CLIENT_REMOTECLOSED)))
+            {
 
-  /*******ACKED**********/  
-  if (uip_acked()) {
-    IF_RF24ETHERNET_DEBUG_CLIENT( Serial.println(); Serial.print(millis()); Serial.println(F(" UIPClient uip_acked")); );
-	u->state &= ~UIP_CLIENT_RESTART;
-	u->hold = (u->out_pos = (u->windowOpened = (u->packets_out = false)));
-	u->connAbortTime = (u->restartTime = millis());	
-  }
-	
-  /*******Polling**********/
-  if (uip_poll() || uip_rexmit() ){
-    //IF_RF24ETHERNET_DEBUG_CLIENT( Serial.println(); Serial.println(F("UIPClient uip_poll")); );
-    
-	if (u->packets_out != 0 ) {
-	  uip_len = u->out_pos;
-	  uip_send(u->myData,u->out_pos);
-	  u->hold = true;
-      u->sent = true;
-	  goto finish;    
-	}else
-    // Restart mechanism to keep connections going
-	// Only call this if the TCP window has already been re-opened, the connection is being polled, but no data
-	// has been acked
-	if( !(u->state & (UIP_CLIENT_CLOSE | UIP_CLIENT_REMOTECLOSED)) ){
-	  
-	  if( u->windowOpened == true && u->state & UIP_CLIENT_RESTART && millis() - u->restartTime > u->restartInterval ){		
-		u->restartTime = millis();		    
-		// Abort the connection if the connection is dead after a set timeout period (uip-conf.h)
-		#if defined UIP_CONNECTION_TIMEOUT
-		
-		if(millis() - u->connAbortTime >= UIP_CONNECTION_TIMEOUT){
-		  #if defined RF24ETHERNET_DEBUG_CLIENT || defined ETH_DEBUG_L1
-		  Serial.println(); Serial.print(millis()); Serial.println(F(" *********** ABORTING CONNECTION ***************"));
-		  #endif
-		  u->windowOpened = false;
-		  u->state = 0;
-		  uip_conn->appstate = NULL;
-		  uip_abort();
-		  goto finish;	      
-		}else{
-		#endif
-		#if defined RF24ETHERNET_DEBUG_CLIENT || defined ETH_DEBUG_L1
-		  Serial.println(); Serial.print(millis()); Serial.print(F(" UIPClient Re-Open TCP Window, time remaining before abort: ")); Serial.println((UIP_CONNECTION_TIMEOUT - (millis() - u->connAbortTime)) / 1000.00);
-		#endif
-		  u->restartInterval+=500;
-		  u->restartInterval=rf24_min(u->restartInterval,7000);
-		  uip_restart();
-		#if defined UIP_CONNECTION_TIMEOUT
-	    }
-		#endif
-	  }
-	}
-  }
+                if (u->windowOpened == true && u->state & UIP_CLIENT_RESTART && millis() - u->restartTime > u->restartInterval)
+                {
+                    u->restartTime = millis();
+// Abort the connection if the connection is dead after a set timeout period (uip-conf.h)
+#if defined UIP_CONNECTION_TIMEOUT
+                    if (millis() - u->connAbortTime >= UIP_CONNECTION_TIMEOUT)
+                    {
+    #if defined RF24ETHERNET_DEBUG_CLIENT || defined ETH_DEBUG_L1
+                        Serial.println();
+                        Serial.print(millis());
+                        Serial.println(F(" *********** ABORTING CONNECTION ***************"));
+    #endif
+                        u->windowOpened = false;
+                        u->state = 0;
+                        uip_conn->appstate = NULL;
+                        uip_abort();
+                        goto finish;
+                    }
+                    else
+                    {
+#endif
+#if defined RF24ETHERNET_DEBUG_CLIENT || defined ETH_DEBUG_L1
+                        Serial.println();
+                        Serial.print(millis());
+                        Serial.print(F(" UIPClient Re-Open TCP Window, time remaining before abort: "));
+                        Serial.println((UIP_CONNECTION_TIMEOUT - (millis() - u->connAbortTime)) / 1000.00);
+#endif
+                        u->restartInterval += 500;
+                        u->restartInterval = rf24_min(u->restartInterval, 7000);
+                        uip_restart();
+#if defined UIP_CONNECTION_TIMEOUT
+                    }
+#endif
+                }
+            }
+        }
 
+        /*******Close**********/
+        if (u->state & UIP_CLIENT_CLOSE)
+        {
+            IF_RF24ETHERNET_DEBUG_CLIENT(Serial.println(); Serial.print(millis()); Serial.println(F(" UIPClient state UIP_CLIENT_CLOSE")););
 
-  /*******Close**********/	
-	
-  if (u->state & UIP_CLIENT_CLOSE) {
-    IF_RF24ETHERNET_DEBUG_CLIENT( Serial.println(); Serial.print(millis()); Serial.println(F(" UIPClient state UIP_CLIENT_CLOSE")); );
+            if (u->packets_out == 0)
+            {
+                u->state = 0;
+                uip_conn->appstate = NULL;
+                uip_close();
+                IF_RF24ETHERNET_DEBUG_CLIENT(Serial.println(F("no blocks out -> free userdata")););
+            }
+            else
+            {
+                uip_stop();
+                IF_RF24ETHERNET_DEBUG_CLIENT(Serial.println(F("blocks outstanding transfer -> uip_stop()")););
+            }
+        }
+    finish:;
 
-	if (u->packets_out == 0) {
-      u->state = 0;
-      uip_conn->appstate = NULL;
-      uip_close();
-      IF_RF24ETHERNET_DEBUG_CLIENT( Serial.println(F("no blocks out -> free userdata")); );
-
-    }else{
-      uip_stop();
-      IF_RF24ETHERNET_DEBUG_CLIENT( Serial.println(F("blocks outstanding transfer -> uip_stop()")); );
+        if (u->state & UIP_CLIENT_RESTART && !u->windowOpened)
+        {
+            if (!(u->state & (UIP_CLIENT_CLOSE | UIP_CLIENT_REMOTECLOSED)))
+            {
+                uip_restart();
+                #if defined ETH_DEBUG_L1
+                Serial.println();
+                Serial.print(millis());
+                Serial.println(F(" UIPClient Re-Open TCP Window"));
+                #endif
+                u->windowOpened = true;
+                u->restartInterval = UIP_WINDOW_REOPEN_DELAY; //.75 seconds
+                u->restartTime = u->connAbortTime = millis();
+            }
+        }
     }
-  }			
-finish:;
-
-  if (u->state & UIP_CLIENT_RESTART && !u->windowOpened) {
-    if( !(u->state & (UIP_CLIENT_CLOSE | UIP_CLIENT_REMOTECLOSED))){	  
-	  uip_restart();
-	  #if defined ETH_DEBUG_L1
-	    Serial.println(); Serial.print(millis()); 
-		Serial.println(F(" UIPClient Re-Open TCP Window"));
-      #endif
-	  u->windowOpened = true;
-	  u->restartInterval = UIP_WINDOW_REOPEN_DELAY; //.75 seconds
-	  u->restartTime = u->connAbortTime = millis();
-	}
-  }
-  }
-  
-
-
 }
 
 /*******************************************************/
 
-
-uip_userdata_t *RF24Client::_allocateData() {
-  for ( uint8_t sock = 0; sock < UIP_CONNS; sock++ ) {
-	uip_userdata_t* data = &RF24Client::all_data[sock];
-    if (!data->state) {
-	  data->state = sock | UIP_CLIENT_CONNECTED;
-	  data->packets_in=0;
-	  data->packets_out=0;
-	  data->dataCnt = 0;
-	  data->dataPos=0;
-	  data->out_pos = 0;
-      data->hold=0;
-	  return data;
-	}
-  }
-  return NULL;
-}
-
-int RF24Client::waitAvailable(uint32_t timeout){
-
-	uint32_t start = millis();
-    while(available() < 1){	
-		if(millis()-start > timeout){
-		  return 0; 
-		}
-		RF24Ethernet.tick();
-	}
-	return available();
-}
-
-/*************************************************************/
-
-int RF24Client::available() {
-  
-  RF24Ethernet.tick();    
-  if (*this){	
-	return _available(data);
-  }
-  return 0;
-}
-
-/*************************************************************/
-
-int RF24Client::_available(uip_userdata_t *u) {
-  if(u->packets_in){
-	return u->dataCnt;
-  }
-  return 0;
-}
-
-int RF24Client::read(uint8_t *buf, size_t size) {
-
-  if (*this) {
-
-    if (!data->packets_in) { return -1; }
-
-    size = rf24_min(data->dataCnt,size);
-	memcpy(buf,&data->myDataIn[data->dataPos],size);
-	data->dataCnt -= size;
-	
-	data->dataPos+=size;
-	
-	if(!data->dataCnt) {
-      
-	  data->packets_in = 0;
-	  data->dataPos = 0;
-	  
-      if (uip_stopped(&uip_conns[data->state & UIP_CLIENT_SOCKETS]) && !(data->state & (UIP_CLIENT_CLOSE | UIP_CLIENT_REMOTECLOSED))){
-        data->state |= UIP_CLIENT_RESTART;
-		data->restartTime = 0;
-		
-		IF_ETH_DEBUG_L2( Serial.print(F("UIPClient set restart ")); Serial.println(data->state & UIP_CLIENT_SOCKETS); Serial.println(F("**")); Serial.println(data->state,BIN); Serial.println(F("**")); Serial.println(UIP_CLIENT_SOCKETS,BIN); Serial.println(F("**"));  );
-	  }else{
-		IF_ETH_DEBUG_L2( Serial.print(F("UIPClient stop?????? ")); Serial.println(data->state & UIP_CLIENT_SOCKETS); Serial.println(F("**")); Serial.println(data->state,BIN); Serial.println(F("**")); Serial.println(UIP_CLIENT_SOCKETS,BIN); Serial.println(F("**"));  );
-			  
-	  }
-	  
-      if (data->packets_in == 0) {
-        if (data->state & UIP_CLIENT_REMOTECLOSED) {
-          data->state = 0;
-          data = NULL;
-        }        
-      }
+uip_userdata_t *RF24Client::_allocateData()
+{
+    for (uint8_t sock = 0; sock < UIP_CONNS; sock++)
+    {
+        uip_userdata_t *data = &RF24Client::all_data[sock];
+        if (!data->state)
+        {
+            data->state = sock | UIP_CLIENT_CONNECTED;
+            data->packets_in = 0;
+            data->packets_out = 0;
+            data->dataCnt = 0;
+            data->dataPos = 0;
+            data->out_pos = 0;
+            data->hold = 0;
+            return data;
+        }
     }
-    return size;
-  }
-  
-  return -1;
+    return NULL;
+}
+
+int RF24Client::waitAvailable(uint32_t timeout)
+{
+    uint32_t start = millis();
+    while (available() < 1)
+    {
+        if (millis() - start > timeout)
+        {
+            return 0;
+        }
+        RF24Ethernet.tick();
+    }
+    return available();
 }
 
 /*************************************************************/
 
-int RF24Client::read() {
-  uint8_t c;
-  if (read(&c,1) < 0)
+int RF24Client::available()
+{
+    RF24Ethernet.tick();
+    if (*this)
+    {
+        return _available(data);
+    }
+    return 0;
+}
+
+/*************************************************************/
+
+int RF24Client::_available(uip_userdata_t *u)
+{
+    if (u->packets_in)
+    {
+        return u->dataCnt;
+    }
+    return 0;
+}
+
+int RF24Client::read(uint8_t *buf, size_t size)
+{
+    if (*this)
+    {
+        if (!data->packets_in)
+        {
+            return -1;
+        }
+
+        size = rf24_min(data->dataCnt, size);
+        memcpy(buf, &data->myDataIn[data->dataPos], size);
+        data->dataCnt -= size;
+
+        data->dataPos += size;
+
+        if (!data->dataCnt)
+        {
+            data->packets_in = 0;
+            data->dataPos = 0;
+
+            if (uip_stopped(&uip_conns[data->state & UIP_CLIENT_SOCKETS]) && !(data->state & (UIP_CLIENT_CLOSE | UIP_CLIENT_REMOTECLOSED)))
+            {
+                data->state |= UIP_CLIENT_RESTART;
+                data->restartTime = 0;
+
+                IF_ETH_DEBUG_L2(Serial.print(F("UIPClient set restart ")); Serial.println(data->state & UIP_CLIENT_SOCKETS); Serial.println(F("**")); Serial.println(data->state, BIN); Serial.println(F("**")); Serial.println(UIP_CLIENT_SOCKETS, BIN); Serial.println(F("**")););
+            }
+            else
+            {
+                IF_ETH_DEBUG_L2(Serial.print(F("UIPClient stop?????? ")); Serial.println(data->state & UIP_CLIENT_SOCKETS); Serial.println(F("**")); Serial.println(data->state, BIN); Serial.println(F("**")); Serial.println(UIP_CLIENT_SOCKETS, BIN); Serial.println(F("**")););
+            }
+
+            if (data->packets_in == 0)
+            {
+                if (data->state & UIP_CLIENT_REMOTECLOSED)
+                {
+                    data->state = 0;
+                    data = NULL;
+                }
+            }
+        }
+        return size;
+    }
+
     return -1;
-  return c;
 }
 
 /*************************************************************/
 
-int RF24Client::peek() {
-	if(available()){
-	  return data->myDataIn[data->dataPos];
-	}
-  return -1;
+int RF24Client::read()
+{
+    uint8_t c;
+    if (read(&c, 1) < 0)
+        return -1;
+    return c;
 }
 
 /*************************************************************/
 
-void RF24Client::flush() {
-  if (*this) {
-	data->packets_in = 0;
-	data->dataCnt = 0;
-  }
+int RF24Client::peek()
+{
+    if (available())
+    {
+        return data->myDataIn[data->dataPos];
+    }
+    return -1;
 }
 
 /*************************************************************/
+
+void RF24Client::flush()
+{
+    if (*this)
+    {
+        data->packets_in = 0;
+        data->dataCnt = 0;
+    }
+}

--- a/RF24Client.h
+++ b/RF24Client.h
@@ -1,7 +1,7 @@
 
 /*
  RF24Client.h - Arduino implementation of a uIP wrapper class.
- Copyright (c) 2014 tmrh20@gmail.com, github.com/TMRh20 
+ Copyright (c) 2014 tmrh20@gmail.com, github.com/TMRh20
  Copyright (c) 2013 Norbert Truchsess <norbert.truchsess@t-online.de>
  All rights reserved.
  This program is free software: you can redistribute it and/or modify
@@ -15,7 +15,7 @@
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
   */
-  
+
 #ifndef RF24CLIENT_H
 #define RF24CLIENT_H
 
@@ -38,11 +38,11 @@
 /**
  * @warning <b> This is used internally and should not be accessed directly by users </b>
  */
-
 typedef struct {
-  uint8_t state;
-  uint8_t packets_in[UIP_SOCKET_NUMPACKETS];
-  uint16_t lport;        /**< The local TCP port, in network byte order. */
+    uint8_t state;
+    uint8_t packets_in[UIP_SOCKET_NUMPACKETS];
+    /** The local TCP port, in network byte order. */
+    uint16_t lport;
 } uip_userdata_closed_t;
 
 
@@ -51,146 +51,130 @@ typedef struct {
  * @warning <b> This is used internally and should not be accessed directly by users </b>
  */
 typedef struct {
-  uint8_t state;
-  bool packets_in;
-  bool packets_out;
-  uint16_t out_pos;
+    uint8_t state;
+    bool packets_in;
+    bool packets_out;
+    uint16_t out_pos;
 #if UIP_CLIENT_TIMER >= 0
-  unsigned long timer;
+     unsigned long timer;
 #endif
- bool windowOpened;
- uint32_t restartTime;
- uint32_t restartInterval;
- uint32_t connAbortTime;
- uint8_t myData[OUTPUT_BUFFER_SIZE];
- uint8_t myDataIn[OUTPUT_BUFFER_SIZE]; 
- uint16_t dataPos;
- uint16_t dataCnt;
- bool hold;
- bool sent;
+    bool windowOpened;
+    uint32_t restartTime;
+    uint32_t restartInterval;
+    uint32_t connAbortTime;
+    uint8_t myData[OUTPUT_BUFFER_SIZE];
+    uint8_t myDataIn[OUTPUT_BUFFER_SIZE];
+    uint16_t dataPos;
+    uint16_t dataCnt;
+    bool hold;
+    bool sent;
 } uip_userdata_t;
-
-
 
 
 class RF24Client : public Client {
 
 public:
 
-	/**
-	* Basic constructor
-	*/	
-	RF24Client();
-	
-	/**
-	* Establish a connection to a specified IP address and port
-	*/
-	int connect(IPAddress ip, uint16_t port);
-    
-	/**
-	* Establish a connection to a given hostname and port
-	* @note UDP must be enabled in uip-conf.h for DNS lookups to work  
-	* 
-	* @note Tip: DNS lookups generally require a buffer size of 250-300 bytes or greater.
-	* Lookups will generally return responses with a single A record if using hostnames like
-	* "www.google.com" instead of "google.com" which works well with the default buffer size
-	*/
-	int connect(const char *host, uint16_t port);
-    
-	/**
-	* Read available data into a buffer
-	* @code
-	* uint8_t buf[size];
-    * client.read(buf,size);
-	* @endcode
-	*/
-	int read(uint8_t *buf, size_t size);
-	
-	/**
-	* Read data one byte at a time
-	* @code
-	* char c = client.read();
-	* @endcode
-	*/
-	int read();
-	
-	/**
-	* Disconnects from the current active connection
-	*/
-    void stop();  
-  
-	/**
-	* Indicates whether the client is connected or not
-	*/
-	uint8_t connected();
-	
-	/**
-	* Write a single byte of data to the stream
-	* @note This will write an entire TCP payload with only 1 byte in it
-	*/
+    /** Basic constructor */
+    RF24Client();
+
+    /** Establish a connection to a specified IP address and port */
+    int connect(IPAddress ip, uint16_t port);
+
+    /**
+     * Establish a connection to a given hostname and port
+     * @note UDP must be enabled in uip-conf.h for DNS lookups to work
+     *
+     * @note Tip: DNS lookups generally require a buffer size of 250-300 bytes or greater.
+     * Lookups will generally return responses with a single A record if using hostnames like
+     * "www.google.com" instead of "google.com" which works well with the default buffer size
+     */
+    int connect(const char *host, uint16_t port);
+
+    /**
+     * Read available data into a buffer
+     * @code
+     * uint8_t buf[size];
+     * client.read(buf,size);
+     * @endcode
+     */
+    int read(uint8_t *buf, size_t size);
+
+    /**
+     * Read data one byte at a time
+     * @code
+     * char c = client.read();
+     * @endcode
+     */
+    int read();
+
+    /** Disconnects from the current active connection */
+    void stop();
+
+    /** Indicates whether the client is connected or not */
+    uint8_t connected();
+
+    /**
+     * Write a single byte of data to the stream
+     * @note This will write an entire TCP payload with only 1 byte in it
+     */
     size_t write(uint8_t);
-	
-	/**
-	* Write a buffer of data, to be sent in a single TCP packet
-	*/
+
+    /** Write a buffer of data, to be sent in a single TCP packet */
     size_t write(const uint8_t *buf, size_t size);
-    
-	/**
-	* Indicates whether data is available to be read by the client.
-	* @return Returns the number of bytes available to be read
-	* @note Calling client or server available() keeps the IP stack and RF24Network layer running, so needs to be called regularly,  
-    * even when disconnected or delaying for extended periods.  
-	*/
-	int available();
-    
-	/**
-	* Wait Available
-	*
-	* Helps to ensure all incoming data has been received, prior to writing data back to the client, etc.
-	*
-	* Indicates whether data is available to be read by the client, after waiting a maximum period of time.
-	* @return Returns the number of bytes available to be read or 0 if timed out
-	* @note Calling client or server available() keeps the IP stack and RF24Network layer running, so needs to be called regularly,  
-    * even when disconnected or delaying for extended periods.  
-	*/
-	
-	int waitAvailable(uint32_t timeout=750);
-    
-	/**
-	* Read a byte from the incoming buffer without advancing the point of reading
-	*/
-	int peek();
-	
-	/**
-	* Flush all incoming client data from the current connection/buffer
-	*/
+
+    /**
+     * Indicates whether data is available to be read by the client.
+     * @return Returns the number of bytes available to be read
+     * @note Calling client or server available() keeps the IP stack and RF24Network layer running, so needs to be called regularly,
+     * even when disconnected or delaying for extended periods.
+     */
+    int available();
+
+    /**
+     * Wait Available
+     *
+     * Helps to ensure all incoming data has been received, prior to writing data back to the client, etc.
+     *
+     * Indicates whether data is available to be read by the client, after waiting a maximum period of time.
+     * @return Returns the number of bytes available to be read or 0 if timed out
+     * @note Calling client or server available() keeps the IP stack and RF24Network layer running, so needs to be called regularly,
+     * even when disconnected or delaying for extended periods.
+     */
+    int waitAvailable(uint32_t timeout=750);
+
+    /** Read a byte from the incoming buffer without advancing the point of reading */
+    int peek();
+
+    /** Flush all incoming client data from the current connection/buffer */
     void flush();
-    
-	using Print::write;	
-		
+
+    using Print::write;
+
     operator bool();
     virtual bool operator==(const EthernetClient&);
     virtual bool operator!=(const EthernetClient& rhs) { return !this->operator==(rhs); };
 
-	static uip_userdata_t all_data[UIP_CONNS];	
+    static uip_userdata_t all_data[UIP_CONNS];
+
 private:
 
     RF24Client(struct uip_conn *_conn);
     RF24Client(uip_userdata_t* conn_data);
-	
+
     uip_userdata_t* data;
-	
-	static int _available(uip_userdata_t *);	
-    
-	static uip_userdata_t* _allocateData();
-	static size_t _write(uip_userdata_t *,const uint8_t *buf, size_t size);
-	
-	friend class RF24EthernetClass;
-	friend class RF24Server;
-	
-	friend void serialip_appcall(void);
-	friend void uip_log(char* msg);
+
+    static int _available(uip_userdata_t *);
+
+    static uip_userdata_t* _allocateData();
+    static size_t _write(uip_userdata_t *,const uint8_t *buf, size_t size);
+
+    friend class RF24EthernetClass;
+    friend class RF24Server;
+
+    friend void serialip_appcall(void);
+    friend void uip_log(char* msg);
 };
 
 
-#endif
+#endif // RF24CLIENT_H

--- a/RF24Ethernet.cpp
+++ b/RF24Ethernet.cpp
@@ -1,6 +1,6 @@
 /*
  RF24Ethernet.cpp - Arduino implementation of a uIP wrapper class.
- Copyright (c) 2014 tmrh20@gmail.com, github.com/TMRh20 
+ Copyright (c) 2014 tmrh20@gmail.com, github.com/TMRh20
  Copyright (c) 2013 Norbert Truchsess <norbert.truchsess@t-online.de>
  All rights reserved.
 
@@ -19,130 +19,129 @@
   */
 
 #include "RF24Ethernet.h"
-				   
+
 IPAddress RF24EthernetClass::_dnsServerAddress;
 //DhcpClass* RF24EthernetClass::_dhcp(NULL);
 
 /*************************************************************/
-#if defined (RF24_TAP) 
-RF24EthernetClass::RF24EthernetClass(RF24& _radio, RF24Network& _network): radio(_radio),network(_network)
-	//fn_uip_cb(NULL)
-{
-}
+#if defined (RF24_TAP)
+RF24EthernetClass::RF24EthernetClass(RF24& _radio, RF24Network& _network) :
+        radio(_radio), network(_network) //fn_uip_cb(NULL)
+{}
+
 #else // Using RF24Mesh
-RF24EthernetClass::RF24EthernetClass(RF24& _radio, RF24Network& _network, RF24Mesh& _mesh): radio(_radio),network(_network), mesh(_mesh)
-	//fn_uip_cb(NULL)
-{
-}
+RF24EthernetClass::RF24EthernetClass(RF24& _radio, RF24Network& _network, RF24Mesh& _mesh) :
+        radio(_radio), network(_network), mesh(_mesh) //fn_uip_cb(NULL)
+{}
 #endif
+
 /*************************************************************/
 
-void RF24EthernetClass::update() {
-  Ethernet.tick();
+void RF24EthernetClass::update()
+{
+    Ethernet.tick();
 }
 
 /*************************************************************/
 
 void RF24EthernetClass::use_device()
 {
-// Kept for backwards compatibility only
+    // Kept for backwards compatibility only
 }
 
 /*******************************************************/
 
-/*******************************************************/
-void RF24EthernetClass::setMac(uint16_t address){
-	
-	if(!network.multicastRelay){ // Radio has not been started yet
-	  radio.begin();
-	}	
-	
-	const uint8_t mac[6] = {0x52,0x46,0x32,0x34,(uint8_t)address,(uint8_t)(address>>8)};
-	//printf("MAC: %o %d\n",address,mac[0]);
-	
-	#if defined (RF24_TAP)
-	  uip_seteth_addr(mac);
-   	  network.multicastRelay = 1;
-	#else
-     if(mac[0]==1){}; //Dummy operation to prevent warnings if TAP not defined
+void RF24EthernetClass::setMac(uint16_t address)
+{
+    if(!network.multicastRelay){ // Radio has not been started yet
+        radio.begin();
+    }
+
+    const uint8_t mac[6] = {0x52, 0x46, 0x32, 0x34, (uint8_t)address, (uint8_t)(address >> 8)};
+    //printf("MAC: %o %d\n", address, mac[0]);
+
+    #if defined (RF24_TAP)
+    uip_seteth_addr(mac);
+    network.multicastRelay = 1;
+    #else
+    if(mac[0]==1){}; //Dummy operation to prevent warnings if TAP not defined
     #endif
-	RF24_Channel = RF24_Channel ? RF24_Channel : 97;
-	network.begin(RF24_Channel, address);
+    RF24_Channel = RF24_Channel ? RF24_Channel : 97;
+    network.begin(RF24_Channel, address);
 }
 
 /*******************************************************/
 
-void RF24EthernetClass::setChannel(uint8_t channel){
-	
-	RF24_Channel = channel;
-	if(network.multicastRelay){ // Radio has not been started yet
-	  radio.setChannel(RF24_Channel);
-	}
+void RF24EthernetClass::setChannel(uint8_t channel)
+{
+    RF24_Channel = channel;
+    if(network.multicastRelay){ // Radio has not been started yet
+        radio.setChannel(RF24_Channel);
+    }
 }
 
 /*******************************************************/
 
 void RF24EthernetClass::begin(IPAddress ip)
 {
-IPAddress dns = ip;
-dns[3] = 1;
-begin(ip, dns);
+    IPAddress dns = ip;
+    dns[3] = 1;
+    begin(ip, dns);
 }
 
 /*******************************************************/
 
 void RF24EthernetClass::begin(IPAddress ip, IPAddress dns)
 {
-IPAddress gateway = ip;
-gateway[3] = 1;
-begin(ip, dns, gateway);
+    IPAddress gateway = ip;
+    gateway[3] = 1;
+    begin(ip, dns, gateway);
 }
 
 /*******************************************************/
 
 void RF24EthernetClass::begin(IPAddress ip, IPAddress dns, IPAddress gateway)
 {
-IPAddress subnet(255, 255, 255, 0);
-begin(ip, dns, gateway, subnet);
+    IPAddress subnet(255, 255, 255, 0);
+    begin(ip, dns, gateway, subnet);
 }
 
 /*******************************************************/
 
 void RF24EthernetClass::begin(IPAddress ip, IPAddress dns, IPAddress gateway, IPAddress subnet)
 {
-configure(ip,dns,gateway,subnet);
+    configure(ip,dns,gateway,subnet);
 }
 
 /*******************************************************/
 
-void RF24EthernetClass::configure(IPAddress ip, IPAddress dns, IPAddress gateway, IPAddress subnet) {
-
-  #if !defined (RF24_TAP) // Using RF24Mesh
+void RF24EthernetClass::configure(IPAddress ip, IPAddress dns, IPAddress gateway, IPAddress subnet)
+{
+    #if !defined (RF24_TAP) // Using RF24Mesh
     mesh.setNodeID(ip[3]);
-  #endif
-  
-uip_buf = (uint8_t*)&network.frag_ptr->message_buffer[0];
+    #endif
 
-uip_ipaddr_t ipaddr;
-uip_ip_addr(ipaddr, ip);
-uip_sethostaddr(ipaddr);
-uip_ip_addr(ipaddr, gateway);
-uip_setdraddr(ipaddr);
-uip_ip_addr(ipaddr, subnet);
-uip_setnetmask(ipaddr);
-_dnsServerAddress = dns;
+    uip_buf = (uint8_t*)&network.frag_ptr->message_buffer[0];
 
-	timer_set(&this->periodic_timer, CLOCK_SECOND / UIP_TIMER_DIVISOR);
-	
-	#if defined (RF24_TAP)
-	timer_set(&this->arp_timer, CLOCK_SECOND * 2);
-	#endif
-	
-	uip_init();
-	#if defined (RF24_TAP)
-	uip_arp_init();	
-	#endif
+    uip_ipaddr_t ipaddr;
+    uip_ip_addr(ipaddr, ip);
+    uip_sethostaddr(ipaddr);
+    uip_ip_addr(ipaddr, gateway);
+    uip_setdraddr(ipaddr);
+    uip_ip_addr(ipaddr, subnet);
+    uip_setnetmask(ipaddr);
+    _dnsServerAddress = dns;
 
+    timer_set(&this->periodic_timer, CLOCK_SECOND / UIP_TIMER_DIVISOR);
+
+    #if defined (RF24_TAP)
+    timer_set(&this->arp_timer, CLOCK_SECOND * 2);
+    #endif
+
+    uip_init();
+    #if defined (RF24_TAP)
+    uip_arp_init();
+    #endif
 }
 
 /*******************************************************/
@@ -151,137 +150,142 @@ void RF24EthernetClass::set_gateway(IPAddress gwIP)
 {
   uip_ipaddr_t ipaddr;
   uip_ip_addr(ipaddr, gwIP);
-  uip_setdraddr(ipaddr);  
+  uip_setdraddr(ipaddr);
 }
 
 /*******************************************************/
 
 void RF24EthernetClass::listen(uint16_t port)
 {
-  uip_listen(HTONS(port));
-}
-
-/*******************************************************/
- 
-IPAddress RF24EthernetClass::localIP() {
-IPAddress ret;
-uip_ipaddr_t a;
-uip_gethostaddr(a);
-return ip_addr_uip(a);
+    uip_listen(HTONS(port));
 }
 
 /*******************************************************/
 
-IPAddress RF24EthernetClass::subnetMask() {
-IPAddress ret;
-uip_ipaddr_t a;
-uip_getnetmask(a);
-return ip_addr_uip(a);
+IPAddress RF24EthernetClass::localIP()
+{
+    IPAddress ret;
+    uip_ipaddr_t a;
+    uip_gethostaddr(a);
+    return ip_addr_uip(a);
 }
 
 /*******************************************************/
 
-IPAddress RF24EthernetClass::gatewayIP() {
-IPAddress ret;
-uip_ipaddr_t a;
-uip_getdraddr(a);
-return ip_addr_uip(a);
+IPAddress RF24EthernetClass::subnetMask()
+{
+    IPAddress ret;
+    uip_ipaddr_t a;
+    uip_getnetmask(a);
+    return ip_addr_uip(a);
 }
 
 /*******************************************************/
 
-IPAddress RF24EthernetClass::dnsServerIP() {
-return _dnsServerAddress;
+IPAddress RF24EthernetClass::gatewayIP()
+{
+    IPAddress ret;
+    uip_ipaddr_t a;
+    uip_getdraddr(a);
+    return ip_addr_uip(a);
 }
 
 /*******************************************************/
 
-void RF24EthernetClass::tick() {
+IPAddress RF24EthernetClass::dnsServerIP()
+{
+    return _dnsServerAddress;
+}
+
+/*******************************************************/
+
+void RF24EthernetClass::tick()
+{
     #if defined (ARDUINO_ARCH_ESP8266)
-      yield();
+    yield();
     #endif
-	if(RF24Ethernet.network.update() == EXTERNAL_DATA_TYPE){
+    if(RF24Ethernet.network.update() == EXTERNAL_DATA_TYPE){
         if(RF24Ethernet.network.frag_ptr->message_size <= UIP_BUFSIZE){
-		  uip_len = RF24Ethernet.network.frag_ptr->message_size;
+            uip_len = RF24Ethernet.network.frag_ptr->message_size;
         }
-	}
+    }
 
     #if !defined (RF24_TAP)
-	if(uip_len > 0) {
-	  uip_input();
-	  if(uip_len > 0) {
-	    network_send();	
-	  }
-	} else if(timer_expired(&Ethernet.periodic_timer)) {
-      timer_reset(&Ethernet.periodic_timer);
-      for(int i = 0; i < UIP_CONNS; i++) {
-	    uip_periodic(i);
-	    /* If the above function invocation resulted in data that
-	    should be sent out on the network, the global variable
-	    uip_len is set to a value > 0. */
-	    if(uip_len > 0) {
-	      network_send();
-	    }
-      }
-	}
-	#else
     if(uip_len > 0) {
-      if(BUF->type == htons(UIP_ETHTYPE_IP)) {
-	  uip_arp_ipin();
-	  uip_input();
-	/* If the above function invocation resulted in data that
-	   should be sent out on the network, the global variable
-	   uip_len is set to a value > 0. */
-	if(uip_len > 0) {
-	  uip_arp_out();
-	  network_send();
-	}
-      } else if(BUF->type == htons(UIP_ETHTYPE_ARP)) {
-	    uip_arp_arpin();
-	/* If the above function invocation resulted in data that
-	   should be sent out on the network, the global variable
-	   uip_len is set to a value > 0. */
-	if(uip_len > 0) {
-	  network_send();
-	}
-      }
-
-    } else if(timer_expired(&Ethernet.periodic_timer)) {
-      timer_reset(&Ethernet.periodic_timer);
-      for(int i = 0; i < UIP_CONNS; i++) {
-	    uip_periodic(i);
-	   /* If the above function invocation resulted in data that
-	   should be sent out on the network, the global variable
-	   uip_len is set to a value > 0. */
-	   if(uip_len > 0) {
-	     uip_arp_out();
-	     network_send();
-	  }
+        uip_input();
+        if(uip_len > 0) {
+            network_send();
+        }
     }
-    #endif
-#if UIP_UDP
-      for(int i = 0; i < UIP_UDP_CONNS; i++) {
-	uip_udp_periodic(i);
-	/* If the above function invocation resulted in data that
-	   should be sent out on the network, the global variable
-	   uip_len is set to a value > 0. */
-	if(uip_len > 0) {
-	  //uip_arp_out();
-	  //network_send();
-	  RF24UDP::_send((uip_udp_userdata_t *)(uip_udp_conns[i].appstate));
-	}
-      }
-#endif /* UIP_UDP */
-#if defined (RF24_TAP)      
-      /* Call the ARP timer function every 10 seconds. */
-
-	if(timer_expired(&Ethernet.arp_timer)) {
-	  timer_reset(&Ethernet.arp_timer);
-	  uip_arp_timer();
+    else if(timer_expired(&Ethernet.periodic_timer)) {
+        timer_reset(&Ethernet.periodic_timer);
+        for(int i = 0; i < UIP_CONNS; i++) {
+            uip_periodic(i);
+            /* If the above function invocation resulted in data that
+            should be sent out on the network, the global variable
+            uip_len is set to a value > 0. */
+            if(uip_len > 0) {
+                network_send();
+            }
+        }
     }
+    #else // defined (RF24_TAP)
+    if(uip_len > 0) {
+        if(BUF->type == htons(UIP_ETHTYPE_IP)) {
+            uip_arp_ipin();
+            uip_input();
+            /* If the above function invocation resulted in data that
+            should be sent out on the network, the global variable
+            uip_len is set to a value > 0. */
+            if(uip_len > 0) {
+                uip_arp_out();
+                network_send();
+            }
+        }
+        else if(BUF->type == htons(UIP_ETHTYPE_ARP)) {
+            uip_arp_arpin();
+            /* If the above function invocation resulted in data that
+            should be sent out on the network, the global variable
+            uip_len is set to a value > 0. */
+            if(uip_len > 0) {
+                network_send();
+            }
+        }
+    }
+    else if (timer_expired(&Ethernet.periodic_timer)) {
+        timer_reset(&Ethernet.periodic_timer);
+        for(int i = 0; i < UIP_CONNS; i++) {
+            uip_periodic(i);
+            /* If the above function invocation resulted in data that
+            should be sent out on the network, the global variable
+            uip_len is set to a value > 0. */
+            if(uip_len > 0) {
+                uip_arp_out();
+                network_send();
+            }
+        }
+    #endif // defined (RF24_TAP)
+    #if UIP_UDP
+        for(int i = 0; i < UIP_UDP_CONNS; i++) {
+            uip_udp_periodic(i);
+            /* If the above function invocation resulted in data that
+            should be sent out on the network, the global variable
+            uip_len is set to a value > 0. */
+            if(uip_len > 0) {
+                //uip_arp_out();
+                //network_send();
+                RF24UDP::_send((uip_udp_userdata_t *)(uip_udp_conns[i].appstate));
+            }
+        }
+    #endif /* UIP_UDP */
+    #if defined (RF24_TAP)
+        /* Call the ARP timer function every 10 seconds. */
 
-  }
-
+        if(timer_expired(&Ethernet.arp_timer)) {
+            timer_reset(&Ethernet.arp_timer);
+            uip_arp_timer();
+        }
+    }
 #endif //RF24_TAP
 }
 
@@ -291,20 +295,20 @@ void RF24EthernetClass::network_send()
 {
     RF24NetworkHeader headerOut(00,EXTERNAL_DATA_TYPE);
     #if defined ETH_DEBUG_L1 || defined ETH_DEBUG_L2
-      bool ok = RF24Ethernet.network.write(headerOut,uip_buf,uip_len);
+    bool ok = RF24Ethernet.network.write(headerOut, uip_buf, uip_len);
     #else
-      RF24Ethernet.network.write(headerOut,uip_buf,uip_len);
+    RF24Ethernet.network.write(headerOut, uip_buf, uip_len);
     #endif
 
     #if defined ETH_DEBUG_L1 || defined ETH_DEBUG_L2
-      if(!ok){
-        Serial.println(); Serial.print(millis()); Serial.println(F(" *** RF24Ethernet Network Write Fail ***")); 
-      }
+        if(!ok){
+            Serial.println(); Serial.print(millis()); Serial.println(F(" *** RF24Ethernet Network Write Fail ***"));
+        }
     #endif
     #if defined ETH_DEBUG_L2
-      if(ok){
-        Serial.println(); Serial.print(millis()); Serial.println(F(" RF24Ethernet Network Write OK")); 
-      }
+        if(ok){
+            Serial.println(); Serial.print(millis()); Serial.println(F(" RF24Ethernet Network Write OK"));
+        }
     #endif
 
 }
@@ -314,6 +318,3 @@ void RF24EthernetClass::network_send()
 void uipudp_appcall(){
 
 }*/
-
-/*******************************************************/
-

--- a/RF24Ethernet.cpp
+++ b/RF24Ethernet.cpp
@@ -53,7 +53,7 @@ void RF24EthernetClass::use_device()
 
 void RF24EthernetClass::setMac(uint16_t address)
 {
-    if(!network.multicastRelay){ // Radio has not been started yet
+    if (!network.multicastRelay) { // Radio has not been started yet
         radio.begin();
     }
 
@@ -64,7 +64,7 @@ void RF24EthernetClass::setMac(uint16_t address)
     uip_seteth_addr(mac);
     network.multicastRelay = 1;
     #else
-    if(mac[0]==1){}; //Dummy operation to prevent warnings if TAP not defined
+    if (mac[0]==1) {}; //Dummy operation to prevent warnings if TAP not defined
     #endif
     RF24_Channel = RF24_Channel ? RF24_Channel : 97;
     network.begin(RF24_Channel, address);
@@ -75,7 +75,7 @@ void RF24EthernetClass::setMac(uint16_t address)
 void RF24EthernetClass::setChannel(uint8_t channel)
 {
     RF24_Channel = channel;
-    if(network.multicastRelay){ // Radio has not been started yet
+    if (network.multicastRelay) { // Radio has not been started yet
         radio.setChannel(RF24_Channel);
     }
 }
@@ -204,50 +204,50 @@ void RF24EthernetClass::tick()
     #if defined (ARDUINO_ARCH_ESP8266)
     yield();
     #endif
-    if(RF24Ethernet.network.update() == EXTERNAL_DATA_TYPE){
-        if(RF24Ethernet.network.frag_ptr->message_size <= UIP_BUFSIZE){
+    if (RF24Ethernet.network.update() == EXTERNAL_DATA_TYPE) {
+        if (RF24Ethernet.network.frag_ptr->message_size <= UIP_BUFSIZE) {
             uip_len = RF24Ethernet.network.frag_ptr->message_size;
         }
     }
 
     #if !defined (RF24_TAP)
-    if(uip_len > 0) {
+    if (uip_len > 0) {
         uip_input();
-        if(uip_len > 0) {
+        if (uip_len > 0) {
             network_send();
         }
     }
-    else if(timer_expired(&Ethernet.periodic_timer)) {
+    else if (timer_expired(&Ethernet.periodic_timer)) {
         timer_reset(&Ethernet.periodic_timer);
         for(int i = 0; i < UIP_CONNS; i++) {
             uip_periodic(i);
             /* If the above function invocation resulted in data that
             should be sent out on the network, the global variable
             uip_len is set to a value > 0. */
-            if(uip_len > 0) {
+            if (uip_len > 0) {
                 network_send();
             }
         }
     }
     #else // defined (RF24_TAP)
-    if(uip_len > 0) {
-        if(BUF->type == htons(UIP_ETHTYPE_IP)) {
+    if (uip_len > 0) {
+        if (BUF->type == htons(UIP_ETHTYPE_IP)) {
             uip_arp_ipin();
             uip_input();
             /* If the above function invocation resulted in data that
             should be sent out on the network, the global variable
             uip_len is set to a value > 0. */
-            if(uip_len > 0) {
+            if (uip_len > 0) {
                 uip_arp_out();
                 network_send();
             }
         }
-        else if(BUF->type == htons(UIP_ETHTYPE_ARP)) {
+        else if (BUF->type == htons(UIP_ETHTYPE_ARP)) {
             uip_arp_arpin();
             /* If the above function invocation resulted in data that
             should be sent out on the network, the global variable
             uip_len is set to a value > 0. */
-            if(uip_len > 0) {
+            if (uip_len > 0) {
                 network_send();
             }
         }
@@ -259,7 +259,7 @@ void RF24EthernetClass::tick()
             /* If the above function invocation resulted in data that
             should be sent out on the network, the global variable
             uip_len is set to a value > 0. */
-            if(uip_len > 0) {
+            if (uip_len > 0) {
                 uip_arp_out();
                 network_send();
             }
@@ -271,7 +271,7 @@ void RF24EthernetClass::tick()
             /* If the above function invocation resulted in data that
             should be sent out on the network, the global variable
             uip_len is set to a value > 0. */
-            if(uip_len > 0) {
+            if (uip_len > 0) {
                 //uip_arp_out();
                 //network_send();
                 RF24UDP::_send((uip_udp_userdata_t *)(uip_udp_conns[i].appstate));
@@ -281,7 +281,7 @@ void RF24EthernetClass::tick()
     #if defined (RF24_TAP)
         /* Call the ARP timer function every 10 seconds. */
 
-        if(timer_expired(&Ethernet.arp_timer)) {
+        if (timer_expired(&Ethernet.arp_timer)) {
             timer_reset(&Ethernet.arp_timer);
             uip_arp_timer();
         }
@@ -301,12 +301,12 @@ void RF24EthernetClass::network_send()
     #endif
 
     #if defined ETH_DEBUG_L1 || defined ETH_DEBUG_L2
-        if(!ok){
+        if (!ok) {
             Serial.println(); Serial.print(millis()); Serial.println(F(" *** RF24Ethernet Network Write Fail ***"));
         }
     #endif
     #if defined ETH_DEBUG_L2
-        if(ok){
+        if (ok) {
             Serial.println(); Serial.print(millis()); Serial.println(F(" RF24Ethernet Network Write OK"));
         }
     #endif
@@ -315,6 +315,6 @@ void RF24EthernetClass::network_send()
 
 /*******************************************************/
 /*
-void uipudp_appcall(){
+void uipudp_appcall() {
 
 }*/

--- a/RF24Ethernet.h
+++ b/RF24Ethernet.h
@@ -29,15 +29,15 @@
  * Class declaration for RF24Ethernet
  */
 
- #include <Arduino.h>
+#include <Arduino.h>
 
 extern "C" {
-  #include "uip-conf.h"
-  #include "utility/uip.h"
-  #include "utility/timer.h"
-  #include "utility/uip_arp.h"
-
+    #include "uip-conf.h"
+    #include "utility/uip.h"
+    #include "utility/timer.h"
+    #include "utility/uip_arp.h"
 }
+
 #include "RF24Ethernet_config.h"
 #include <RF24.h>
 #include <RF24Network.h>
@@ -54,8 +54,6 @@ extern "C" {
 #include "RF24Udp.h"
 #include "Dns.h"
 #endif
-
-
 
 #define UIPETHERNET_FREEPACKET 1
 #define UIPETHERNET_SENDPACKET 2
@@ -90,136 +88,123 @@ extern "C" {
 
 
 /**
-* @warning <b>This is used internally. Use IPAddress instead. </b>
-*/
+ * @warning <b>This is used internally. Use IPAddress instead. </b>
+ */
 typedef struct {
-	int a, b, c, d;
+    int a, b, c, d;
 } IP_ADDR;
-
-
 
 class RF24;
 class RF24Network;
 
-
 class RF24EthernetClass {//: public Print {
-	public:
+public:
 
-		/**
-		* Constructor to set up the Ethernet layer. Requires the radio and network to be configured by the user
-		* this allows users to set custom settings at the radio or network level
-		*/
-        #if !defined (RF24_TAP) // Using RF24Mesh
-		RF24EthernetClass(RF24& _radio,RF24Network& _network, RF24Mesh& _mesh);
-		#else
-        RF24EthernetClass(RF24& _radio,RF24Network& _network);
-        #endif
-		/**
-		* Basic constructor
-		*/
-		RF24EthernetClass();
+    /**
+     * Constructor to set up the Ethernet layer. Requires the radio and network to be configured by the user
+     * this allows users to set custom settings at the radio or network level
+     */
+    #if !defined (RF24_TAP) // Using RF24Mesh
+    RF24EthernetClass(RF24& _radio,RF24Network& _network, RF24Mesh& _mesh);
+    #else
+    RF24EthernetClass(RF24& _radio,RF24Network& _network);
+    #endif
 
-		/**
-		* @note Deprecated, maintained for backwards compatibility with old examples
-		*
-		* This function is no longer needed, and does nothing
-		*/
-		void use_device();
+    /** Basic constructor */
+    RF24EthernetClass();
 
-		/**
-		* Configure the IP address and subnet mask of the node. This is independent of the RF24Network layer, so the IP
-		* and subnet only have to conform to standard IP routing rules within your network
-		*/
-		void begin(IP_ADDR myIP, IP_ADDR subnet);
+    /**
+     * @note Deprecated, maintained for backwards compatibility with old examples
+     *
+     * This function is no longer needed, and does nothing
+     */
+    void use_device();
 
-		/**
-		* Configure the IP address and subnet mask of the node. This is independent of the RF24Network layer, so the IP
-		* and subnet only have to conform to standard IP routing rules within your network
-		*/
-		void begin(IPAddress ip);
-		void begin(IPAddress ip, IPAddress dns);
-		void begin(IPAddress ip, IPAddress dns, IPAddress gateway);
-		void begin(IPAddress ip, IPAddress dns, IPAddress gateway, IPAddress subnet);
+    /**
+     * Configure the IP address and subnet mask of the node. This is independent of the RF24Network layer, so the IP
+     * and subnet only have to conform to standard IP routing rules within your network
+     */
+    void begin(IP_ADDR myIP, IP_ADDR subnet);
 
+    /**
+     * Configure the IP address and subnet mask of the node. This is independent of the RF24Network layer, so the IP
+     * and subnet only have to conform to standard IP routing rules within your network
+     */
+    void begin(IPAddress ip);
+    void begin(IPAddress ip, IPAddress dns);
+    void begin(IPAddress ip, IPAddress dns, IPAddress gateway);
+    void begin(IPAddress ip, IPAddress dns, IPAddress gateway, IPAddress subnet);
 
-		/**
-		* Configure the gateway IP address. This is generally going to be your master node with RF24Network address 00.
-		*/
-		void set_gateway(IPAddress gwIP);
+    /**
+     * Configure the gateway IP address. This is generally going to be your master node with RF24Network address 00.
+     */
+    void set_gateway(IPAddress gwIP);
 
-		/**
-		* Listen to a specified port - This will likely be changed to closer match the Arduino Ethernet API with server.begin();
-		*/
-		void listen(uint16_t port);
+    /**
+     * Listen to a specified port - This will likely be changed to closer match the Arduino Ethernet API with server.begin();
+     */
+    void listen(uint16_t port);
 
-		/* *
-		* Sets the MAC address of the RF24 module, which is an RF24Network address
-		* Specify an Octal address to assign to this node, which will be used as the Ethernet mac address
-		* If setting up only a few nodes, use 01 to 05
-		* Please reference the RF24Network documentation for information on setting up a static network
-		* RF24Mesh will be integrated to provide this automatically
-		*/
-		void setMac(uint16_t address);
+    /**
+     * Sets the MAC address of the RF24 module, which is an RF24Network address
+     * Specify an Octal address to assign to this node, which will be used as the Ethernet mac address
+     * If setting up only a few nodes, use 01 to 05
+     * Please reference the RF24Network documentation for information on setting up a static network
+     * RF24Mesh will be integrated to provide this automatically
+     */
+    void setMac(uint16_t address);
 
-		/** Sets the Radio channel/frequency to use (0-127)
-		*/
-		void setChannel(uint8_t channel);
+    /** Sets the Radio channel/frequency to use (0-127) */
+    void setChannel(uint8_t channel);
 
+    /** Indicates whether data is available. */
+    int available();
 
-	/** Indicates whether data is available.
-	*/
-	int available();
+    /** Returns the local IP address */
+    IPAddress localIP();
 
-	/** Returns the local IP address
-	*/
-	IPAddress localIP();
-	/** Returns the subnet mask
-	*/
-	IPAddress subnetMask();
-	/** Returns the gateway IP address
-	*/
-	IPAddress gatewayIP();
-	/** Returns the DNS server IP address
-	*/
-	IPAddress dnsServerIP();
+    /** Returns the subnet mask */
+    IPAddress subnetMask();
 
-	/** Keeps the TCP/IP stack running & processing incoming data
-	*/
-	void update();
+    /** Returns the gateway IP address */
+    IPAddress gatewayIP();
+
+    /** Returns the DNS server IP address */
+    IPAddress dnsServerIP();
+
+    /** Keeps the TCP/IP stack running & processing incoming data */
+    void update();
     //uint8_t *key;
 
-	private:
-		RF24& radio;
-		RF24Network& network;
-        #if !defined (RF24_TAP) // Using RF24Mesh
-        RF24Mesh& mesh;
-		#endif
+private:
+    RF24& radio;
+    RF24Network& network;
+    #if !defined (RF24_TAP) // Using RF24Mesh
+    RF24Mesh& mesh;
+    #endif
 
-		static IPAddress _dnsServerAddress;
-		void configure(IPAddress ip, IPAddress dns, IPAddress gateway, IPAddress subnet);
-		// tick() must be called at regular intervals to process the incoming serial
-		// data and issue IP events to the sketch.  It does not return until all IP
-		// events have been processed.
-		static void tick();
-		static void network_send();
+    static IPAddress _dnsServerAddress;
+    void configure(IPAddress ip, IPAddress dns, IPAddress gateway, IPAddress subnet);
+    // tick() must be called at regular intervals to process the incoming serial
+    // data and issue IP events to the sketch.  It does not return until all IP
+    // events have been processed.
+    static void tick();
+    static void network_send();
 
-		uint8_t RF24_Channel;
+    uint8_t RF24_Channel;
 
-		struct timer periodic_timer;
-		#if defined RF24_TAP
-		struct timer arp_timer;
-		#endif
-		friend class RF24Server;
-		friend class RF24Client;
-		friend class RF24UDP;
+    struct timer periodic_timer;
+    #if defined RF24_TAP
+    struct timer arp_timer;
+    #endif
+    friend class RF24Server;
+    friend class RF24Client;
+    friend class RF24UDP;
 };
 
 extern RF24EthernetClass RF24Ethernet;
 
-
-#endif
-
-
+#endif // RF24Ethernet_h
 
 /**
  * @example Getting_Started_SimpleServer_Mesh.ino
@@ -275,343 +260,3 @@ extern RF24EthernetClass RF24Ethernet;
  * <br>This example uses [HTML.h](SLIP__InteractiveServer_2HTML_8h.html) from the
  * example's directory.
  */
-
-/**
- * @mainpage RF24Ethernet library: TCP/IP over RF24Network
- *
- * @section OpenSourceWireless Open & Open-Source IoT Wireless (not WiFi) Networks
- * **An experiment disconnected...**<br>
- * @image html "images/RF24EthernetOverviewImg.jpg" width=70% height=70%
- *
- * @section Goals Goals:
- *
- * - Bring the reliability of TCP/IP and potential of mesh networking/IoT to even the smallest of Arduino devices
- * - Enable self-sustaining wireless sensor networks that seamlessly link together using standard protocols & networking
- * - Simplify & automate it.
- * - Experiment with/document a model for completely open & open-source communication
- *
- *
- * @section News Update News
- * @version <b>1.6.5 - Aug 2020</b>
- * - Identified/Correct memory issue causing 'undefined behaviour' ie: A variety of symptoms depending on memory allocation etc.
- * - Update getting started simple client example
- *
- * @version <b>1.6.4 - Aug 2020 </b>
- * - Fix buggy behaviour on AVR devices. Remove hook to update RF24Ethernet during calls to delay.
- * - Fixes for MQTT example
- * - Major cleanup for warnings and minor issues
- *
- * @version <b>1.6.3 - April 2020 </b>
- * - Update & fix MQTT example
- * - Add dependencies for RF24, RF24Network & RF24Mesh
- *
- * See [version history](VersionInfo.html) for more info
- *
- * @section Config Configuration and Setup
- * The hardest part of setting up is getting the first radio module connected properly. <br>
- * Scroll to the bottom of the [RF24 radio documentation for pin connections](http://nRF24.github.io/RF24/) <br><br>
- * Once you have done that, see the [Configuration and Set-Up](ConfigAndSetup.html) page for general installation and configuration information
- * <br><br>
- * @section DetailOverview Detailed Overview
- * See the <b>[Overview](Overview.html)</b> page
- * <br><br>
- * @section BuildingANetwork Building a Network - Customizing your RF24 TCP/IP network
- * See the [Building a network](CustomNetworks.html) page
- * <br><br>
- * @section AboutTroubleshooting About Troubleshooting
- * The RF24 libraries are divided into layers, generally according to the OSI model, which allows specialized testing and troubleshooting of individual layers.
- * <br>See the [Troubleshooting section](Troubleshooting.html) for general troubleshooting steps.
- *
- * @page RF24EthernetOverview RF24Ethernet Overview
- * @section Overview Overview
- *
- * The RF24Ethernet library was initially designed as an experiment and potential testing tool for [RF24Network](http://nRF24.github.io/RF24Network), an OSI Layer 3 network driver, allowing a Raspberry Pi to
- * act as a TCP/IP gateway or host for connected sensor nodes. An Arduino can interface with any Linux machine or SLIP capable device supporting USB, or
- * preferably, an RPi runs companion software, [RF24Gateway](http://nRF24.github.io/RF24Gateway/), which creates a network interface linked to the RF24 radio network. This interface can be
- * further linked to the local network or internet. This allows the RPi or Arduino-based gateway to perform automatic discovery and routing of TCP/IP data,
- * with no required pre-configuration or interaction from the user beyond assigning appropriate addresses to the nodes initially.
- *
- * @section What What does it do?
- *
- * RF24Ethernet creates a network of internet enabled RF24/Arduino sensors. It provides an API and interface very similar to the Arduino Ethernet library,
- * to allow sensor nodes to connect out to local or internet based devices to retrieve or send information, or be connected to from the internet or your
- * local network directly.
- *
- * Sensor nodes can act as individual web servers, simple command-and-control servers, or can connect out as required via TCP/IP.
- *
- *
- * @section How How does it work?
- *
- * RF24Ethernet utilizes the UIP TCP/IP stack, allowing Arduino devices to use a Raspberry Pi running [RF24Gateway](http://nRF24.github.io/RF24Gateway/) or Arduino
- * as a gateway to your network or the internet, or simply as a repository for sensor information. The RF24, RF24Network and optionally RF24Mesh libraries
- * handle the underlying routing, addressing etc. so users do not need to be familiar with the radio modules or libraries.
- *
- * RF24Network addresses need to be assigned as MAC addresses, and IP addresses can be configured as desired by the user. The master node (00) uses
- * either the Address Resolution Protocol (ARP) or RF24Mesh to find the appropriate nodes when IP traffic is sent though, and routes traffic to the correct
- * RF24Network address.
- *
- * This provides a fairly seamless interaction, since users only need to configure standard IP forwarding and firewall rules as desired.
- *
- * The RF24 libraries are based on the [OSI model](http://en.wikipedia.org/wiki/OSI_model):<br>
- * | System                 | OSI Layer              | Description |
- * |------------------------|------------------------|---------------------------------------------------------------------------|
- * | <b>NRF24L01 Radio Modules</b> | OSI Layer 1 (Physical) | Transmission and reception of the raw bit stream over the physical medium. |
- * | <b>RF24 Core Radio Driver</b> | OSI Layer 2 (Data Link)| Transfer of data frames over the physical link. Establish/Terminate logical links between nodes. Manage acknowledgements, error checking |
- * | <b>RF24Network</b>            | OSI Layer 3 (Network)  | Routing, subnets, subnet traffic control, logical-to-physical address mapping, frame fragmentation/reassembly.|
- * | <b>RF24Ethernet (uIP)</b>           | OSI Layer 4 (Transport)| Ensures error-free messages. Manages sequencing, losses, retries, and duplicates. |
- * | <b>RF24Ethernet (core)</b>          | OSI Layer 5 (Session)  | Establish, maintain, and terminate connections |
- * | <b>RF24Mesh</b> -Optional-     | OSI Layer 7 (Application)| Provides DHCP/DNS type protocols and allows dynamic addressing/topology for RF24Network.
- *
- *
- *
- * **TAP vs TUN:**
- *
- * RF24Ethernet and RF24Gateway are able to utilize both TAP and TUN type interfaces. <br>
- * <b> TAP -</b> A TAP interface can be looked at much the same as an Ethernet interface, Ethernet headers are used to identify devices via MAC address, and the Address
- * Resolution Protocol (ARP) is used to perform that identification. <br>
- * <b> TUN -</b> A TUN interface does not utilize Ethernet headers, MAC addresses or ARP, in this case relying on RF24Mesh/IP routing instead.
- *
- * **Limitations:**
- *
- * UDP frames can be up to 512 bytes in length, so UDP/DNS is limited by available memory, and the defined MAX_PAYLOAD_SIZE / UIP_BUFFER_SIZE. If a
- * DNS request exceeds the maximum allowed size, it will be dropped. DNS responses for addresses such as 'www.google.com' tend to be much smaller than requests
- * for 'google.com', and will generally work with the default configuration.
- *
- * **MAC address formatting:**
- *
- * RF24Ethernet uses a simple method of formatting the MAC addresses, using the first four bytes to store the characters 'RF24', and the last two bytes to store the
- * RF24Network address, which makes identification of nodes via MAC address very simple using standard monitoring tools.
- *
- * | RF24Network Address| Byte 0 | Byte 1 | Byte 2 | Byte 3 | Byte 4 | Byte 5 |
- * |--------------------|--------|--------|--------|--------|--------|--------|
- * |      n/a           |   R    |   F    |   2    |   4    |Octal LB|Octal HB|
- * |      01            |  0x52  |  0x46  |  0x32  |   0x34 |  0x01  |  0x00  |
- * |      011           |  0x52  |  0x46  |  0x32  |   0x34 |  0x09  |  0x00  |
- * |      0443          |  0x52  |  0x46  |  0x32  |   0x34 |  0x23  |  0x01  |
- *
- * <br><br>
- *
- * @page ConfigAndSetup Configuration and Set-Up
- *
- * RF24Ethernet requires the RF24 and RF24Network libraries (optionally RF24Mesh) <br>
- * See http://tmrh20.github.io for documentation and downloads <br>
- *
- * See the video at https://www.youtube.com/watch?v=rBAIqAaRu0g for a walk-through of the software setup with Raspberry Pi and Arduino.
- *  <br><br>
- *  <b> RPi </b>
- *
- * On the Raspberry Pi, a companion program, <a href="http://nRF24.github.io/RF24Gateway/">RF24Gateway</a> must be installed along with the RF24 and RF24Network libraries
- * 1. @code wget http://tmrh20.github.io/RF24Installer/RPi/install.sh  @endcode
- * 2. @code chmod +x install.sh  @endcode
- * 3. @code ./install.sh  @endcode
- * 4. @code cd RF24Gateway/examples/ncurses @endcode
- * 5. @code make @endcode
- * 6. @code sudo ./RF24Gateway_ncurses @endcode
- * 7. The application will require the user to specify an IP address and Subnet Mask: 10.10.2.2 and 255.255.255.0 are the defaults with RF24Ethernet examples
- * 8. Raspberry Pi defaults to the master node (00) using RF24Mesh. Secondary Raspberry pi nodes need to specify their RF24Network address or RF24Mesh nodeID.
- *
- *<b> Arduino </b>
- * 1. For Arduino devices, use the Arduino Library Manager to install the RF24 libraries
- * 2. Open the included Getting_Started_SimpleServer or Getting_Started_SimpleClient example
- * 3. Configure your chosen CE and CS pins for the radio connection.
- * 4. Configure the RF24Mesh nodeID (Any unique value from 3 to 255)
- * 5. Configure the IP address according to your preferences, (last octet must==nodeID) with the gateway set to the chosen IP of the RPi.
- * 6. Connect into your nodes web-server at http://ip-of-your-node:1000 from the RPi or configure the client sketch to connect to a server
- * running on the Raspberry Pi.
- * Note: To minimize memory usage on Arduino, edit RF24Network_config.h with a text editor, and uncomment `#define DISABLE_USER_PAYLOADS`. This
- * will disable standard RF24Network messages, and only allow external data, such as TCP/IP information. Remember to comment for normal operation!
- *
- * <b> Non-Raspberry Pi (Linux etc) Devices </b><br>
- * Arduino can also function as a gateway for any Linux machine or PC/MAC that supports SLIP. <br>
- * See the SLIP_Gateway and SLIP_InteractiveServer
- * examples for usage without the need for a Raspberry Pi.
- *
- * <b>Accessing External Systems: Forwarding and Routing</b>
- *
- * In order to give your network or nodes access to your network or the internet beyond the RPi, it needs to be configured to route traffic
- * between the networks.
- * 1. Run @code sudo sysctl -w net.ipv4.ip_forward=1 @endcode to allow the RPi to forward requests between the network interfaces
- * 2. @code sudo iptables -t nat -A POSTROUTING -j MASQUERADE @endcode to allow the RPi to perform NAT between the network interfaces <br>
- *
- * @note This configuration is generally for initial testing only. Users may also need to add a static route to their local machine, or configure port forwarding on the RPi.<br>
- * See the following links for more information on configuring and using IPTables:<br>
- * http://www.karlrupp.net/en/computer/nat_tutorial<br>
- * http://serverfault.com/questions/326493/basic-iptables-nat-port-forwarding
- *
- * @warning <b>Note:</b> Users are responsible to manage further routing rules along with their IP traffic in order to prevent unauthorized access.
- *
- * @section Advanced Advanced (uIP) Configuration and Info
- *
- * See the <a href="group__UipConfiguration.html">User Configuration</a> section for modifying uip-conf.h
- *
- *
- *
- * @page CustomNetworks Building an RF24Ethernet Network
- *
- *
- * The general configuration instructions set up a basic sensor network, with static nodes, using TCP/IP over RF24Network. The layered
- * library design also allows some nodes to communicate solely at the RF24Network level, creating hybrid networks to extend range over
- * large distances, or improve connectivity in distant areas.
- *
- *
- * @section RF24Mesh RF24Mesh Networks
- *
- * RF24Mesh allows dynamic configuration of RF24Network addresses, and allows the creation of dynamic sensor networks. Nodes are able
- * to move around physically, releasing and renewing their RF24Network address as required. Once configured with a unique nodeID, nodes using RF24Mesh
- * can automatically configure themselves and join the network as required, with no user interaction.
- *
- * See the included <a href = SimpleServer_mesh_8ino-example.html>SimpleServer_Mesh</a> example for general usage and configuration information
- * with RF24Ethernet.
- *
- * **RF24Mesh** - Additional Information
- *
- * When utilizing RF24Mesh along with RF24Ethernet, relay/routing nodes should be configured with RF24Mesh, or designated on the master node as static nodes
- * with a pre-configured RF24Network address.
- *
- * RF24Mesh can be used with TAP/Ethernet configurations, but utilizing TUN/RF24Mesh together will reduce overhead.
- *
- * See the links below for more information on utilizing RF24Mesh with RF24Ethernet and RF24Network.
- *
- * @section RF24Gateway RF24Gateway
- *
- * See http://nRF24.github.io/RF24Gateway/ for more information on RF24Gateway
- *
- ** @section HybridNetworks Hybrid- RF24Network/RF24Ethernet Networks
- *
- * The default configuration of RF24Ethernet and RF24Network enables both TCP/IP and the underlying messaging protocols provided by RF24Network.
- *
- * Relay/Routing nodes can be configured using only the RF24 and RF24Network layers (optionally RF24Mesh), and will automatically handle data
- * accordingly, whether it is an external data type (TCP/IP) or an internal network message from another RF24Network node. This allows very small and
- * inexpensive devices such as ATTiny to act as relay/routing nodes when extending network range and/or connectivity.
- *
- * Arduino/AVR devices can utilize custom or included sleep modes in RF24Network, and benefit from the lower power consumption and low-power features
- * of the nrf24l01 chips directly.
- *
- * @section Links Links
- *
- * See http://nRF24.github.io/RF24Mesh for more information on using RF24Mesh to create a dynamic network, with automatic RF24Network addressing <br>
- * See http://nRF24.github.io/RF24Network for more information on using RF24Network as well as addressing and topology.
- * <br><br><br>
- *
- *
- *
- *
- *
- * @page Troubleshooting Troubleshooting
- *
- * @section GeneralTrouble General Troubleshooting
- *  <br>
- * @section Compilation Installation & Compilation Errors:
- * **RPi:** <br> Report issues with the installer at https://github.com/TMRh20/RF24/issues
- *
- * **Arduino:**
- * 1. Ensure proper library installation. <br>
- *  a: Download and install RF24, RF24Network, RF24Mesh and RF24Ethernet libraries from http://tmrh20.github.io <br>
- *  b: See http://arduino.cc/en/Guide/Libraries ( Note: Library folders may need to be renamed ie: Change RF24Network-Development to RF24Network ) <br>
- *
- *  <br>
- * @section HardwareConfig Test hardware configuration
- * **RPi:**<br>
- *  a: Navigate to the rf24libs/RF24/examples_RPi folder<br>
- *  b: Configure the correct pins in gettingstarted.cpp ( See http://www.airspayce.com/mikem/bcm2835/group__constants.html#ga63c029bd6500167152db4e57736d0939 ) <br>
- *  c: Build the examples: @code make @endcode
- *  d: Run an example @code sudo ./gettingstarted @endcode
- *
- * **Arduino:** <br>
- *  a: Open the GettingStarted example sketch (File > Examples > RF24 > GettingStarted) <br>
- *  b: Configure the appropriate CE and CS pins in the example as desired ( RF24 radio(7,8); ) <br>
- *  c: Configure the assigned radio number in the example <br>
- *  d: Upload to Arduino to test <br>
- *
- *  <br>
- * @section TestingTCP Testing RF24Gateway and RF24Ethernet
- * @note Troubleshooting steps assume a fresh library install with the default configuration, using RF24Mesh/TUN
- * @warning The maximum payload size configured in RF24Network_config.h will determine the maximum size of TCP or UDP segments. Set to 1514 (TAP) or 1500 (TUN) on Raspberry Pi/Linux devices for full TCP/IP capabilities. TCP+IP+LL headers add 54 bytes of overhead to each payload with TAP/Ethernet, and 40 bytes with TUN/RF24Mesh
- *
- * **RPi (<a href="http://nRF24.github.io/RF24Gateway/">RF24Gateway</a>):** <br>
- *  a: Run the included RF24Gateway_ncurses example @code sudo ./RF24Gateway_ncurses @endcode
- *  b: Test connectivity: @code ping 10.10.3.<IP_TO_PING-last-octet> @endcode
- *  c: If connectivity fails, ensure IP information is accurate. Forwarding is required if pinging from a device other than the RPi. <br>
- *  d: If using pins connections other than the default, edit the RF24 constructor in the example file: ie: RF24 radio(22,0); <br>
- *  e: Optional: For RPi to RPi communication over RF24, edit the rf24libs/RF24Network/RF24Network_config.h file. Set @code #define MAX_PAYLOAD_SIZE 1514 @endcode
- *
- * **Arduino (RF24Ethernet):** <br>
- *  a: Update all RF24 libraries (RF24, RF24Network, RF24Mesh, RF24Ethernet) http://tmrh20.github.io <br>
- *  b: Open, configure and upload one of the included examples to Arduino. ( File > Examples > RF24Ethernet ) <br>
- *  c: Ensure example hardware and pin configuration matches CE and CS pins selected in step 2 <br>
- *  d: If switching between TAP(Ethernet) & TUN(RF24Mesh), ensure the LLHL is defined appropriately in RF24Ethernet/uip-conf.h: @code #define UIP_CONF_LLH_LEN 14 @endcode
- *
- *
- *
- *<br><br><br>
- *
- *
- *
- * @page VersionInfo Version Info
- *
- * \version <b>1.6.2 - May 2019 </b>
- *
- * \version <b>1.6.1 - Dec 2015</b>
- * - Use Arduino yield() function to keep IP stack updated during calls to delay() etc. (Not working with ESP8266)
- * - Fix mqtt example
- * - Fix (mostly) SLIP gateway example (RPi direct connection preferred)
- * - Fix client operator conversion
- *
- * \version <b>1.6 - Aug-Dec 2015</b>
- * - Address problems with stream functions like client.parseInt() or find()
- * - Tested working with MQTT via <a href="https://github.com/knolleary/pubsubclient">PubSub library</a>
- * - Fix: Connection state set before begin allocated
- * - Workaround for HTTP servers sending half TCP MSS
- * - Automatically assign mesh nodeID based on IP & update examples
- * - <a href="https://github.com/esp8266/Arduino">ESP8266 (Arduino)</a> support
- *
- * \version <b>1.51RC1 - Apr15-16 2015</b>
- * - Seemingly stable release candidate
- * - Major change: <a href="http://nRF24.github.io/RF24Gateway/">RF24Gateway</a> replaces RF24toTUN
- * - Now defaults to using RF24Mesh (TUN) interface
- * - Apr 16 - Use external buffer for uIP to save memory. Requires Updating RF24Network and RF24Mesh.
- *
- * \version <b>1.5RC1 - Apr15-16 2015</b>
- * - Seemingly stable release candidate
- * - Major change: <a href="http://nRF24.github.io/RF24Gateway/">RF24Gateway</a> replaces RF24toTUN
- * - Now defaults to using RF24Mesh (TUN) interface
- * - Apr 16 - Use external buffer for uIP to save memory. Requires Updating RF24Network and RF24Mesh.
- *
- * \version <b>1.4b/1.411b - March 14 - Apr 7 2015 </b>
- * - Add Ethernet.update() function
- * - Improve/Fix outgoing data handling
- * - Fix: Hanging in 1.4b
- *
- * \version <b>1.3b - March 6 2015</b>
- * - Major Improvement: Better TCP window handling increases reliability, throughput and performance
- *
- * \version <b>1.24b - March 3 2015</b>
- * - Utilize separate incoming/outgoing buffers (bugfix)
- * - Update documentation for DNS & UDP
- * - Add waitAvailable() function, update examples to demonstrate usage.
- *
- * \version  <b>1.23b - Jan 22 2015</b>
- *  - Small bugfixes from v1.20
- *  - Slightly reduced latency
- *  - Code clean-up/Reduce code size and memory usage for main Client/Server code
- *  - Cleaned up some examples, added DNS and SimpleServer_Minimal examples
- *
- * \version  <b>1.221b - Jan 16 2015</b>
- *  - Add UDP support
- *  - Add DNS support
- *  - Add support for up to 512 byte buffer size
- *  - Reduce used memory and program space
- *  - Support for multiple connections with per-connection memory  buffers
- *
- * \version  <b>1.1b - Jan 4 2015</b>
- *  - Add connection timeout to recover from hangs during failed client downloads
- *  - Better TCP window management to prevent hangs during client downloads
- *  - Stability improvements
- *
- * \version  <b>1.0b - Dec 2014</b>
- *  - Outgoing client data corruption should be fixed
- */
-
-
-
-

--- a/RF24Ethernet_config.h
+++ b/RF24Ethernet_config.h
@@ -23,7 +23,6 @@
  * @{
  */
 
-
 /*********** USER DEBUG CONFIGURATION *********/
 //#define RF24ETHERNET_DEBUG_CLIENT
 //#define ETH_DEBUG_L1
@@ -37,42 +36,46 @@
 /**
  * Uncomment `#define RF24ETHERNET_DEBUG_CLIENT` to enable main debugging output
  */
-  #if defined (RF24ETHERNET_DEBUG_CLIENT)
+#if defined (RF24ETHERNET_DEBUG_CLIENT)
     #define IF_RF24ETHERNET_DEBUG_CLIENT(x) ({x;})
-  #else
+#else
     #define IF_RF24ETHERNET_DEBUG_CLIENT(x)
-  #endif
-  /**
-   * Uncomment `#define ETH_DEBUG_L1` for debugging window reopening & retransmissions
-   */
-  #if defined (ETH_DEBUG_L1)
-    #define IF_ETH_DEBUG_L1(x) ({x;})
-  #else
-    #define IF_ETH_DEBUG_L1(x)
-  #endif
-  /**
-   * Uncomment `#define ETH_DEBUG_L2` for extra client state debugging
-   */
-  #if defined (ETH_DEBUG_L2)
-    #define IF_ETH_DEBUG_L2(x) ({x;})
-  #else
-    #define IF_ETH_DEBUG_L2(x)
-  #endif
-  /**
-   * Uncomment `#define RF24ETHERNET_DEBUG_UDP` for UDP debugging
-   */
-  #if defined (RF24ETHERNET_DEBUG_UDP)
-    #define IF_RF24ETHERNET_DEBUG_UDP(x) ({x;})
-  #else
-    #define IF_RF24ETHERNET_DEBUG_UDP(x)
-  #endif
-  /**
-   * Uncomment `#define RF24ETHERNET_DEBUG_DNS` for DNS debugging
-   */
-  #if defined (RF24ETHERNET_DEBUG_DNS)
-    #define IF_RF24ETHERNET_DEBUG_DNS(x) ({x;})
-  #else
-    #define IF_RF24ETHERNET_DEBUG_DNS(x)
-  #endif
+#endif
 
-  /** @} */
+/**
+ * Uncomment `#define ETH_DEBUG_L1` for debugging window reopening & retransmissions
+ */
+#if defined (ETH_DEBUG_L1)
+    #define IF_ETH_DEBUG_L1(x) ({x;})
+#else
+    #define IF_ETH_DEBUG_L1(x)
+#endif
+
+/**
+ * Uncomment `#define ETH_DEBUG_L2` for extra client state debugging
+ */
+#if defined (ETH_DEBUG_L2)
+    #define IF_ETH_DEBUG_L2(x) ({x;})
+#else
+    #define IF_ETH_DEBUG_L2(x)
+#endif
+
+/**
+ * Uncomment `#define RF24ETHERNET_DEBUG_UDP` for UDP debugging
+ */
+#if defined (RF24ETHERNET_DEBUG_UDP)
+    #define IF_RF24ETHERNET_DEBUG_UDP(x) ({x;})
+#else
+    #define IF_RF24ETHERNET_DEBUG_UDP(x)
+#endif
+
+/**
+ * Uncomment `#define RF24ETHERNET_DEBUG_DNS` for DNS debugging
+ */
+#if defined (RF24ETHERNET_DEBUG_DNS)
+    #define IF_RF24ETHERNET_DEBUG_DNS(x) ({x;})
+#else
+    #define IF_RF24ETHERNET_DEBUG_DNS(x)
+#endif
+
+/** @} */

--- a/RF24Server.cpp
+++ b/RF24Server.cpp
@@ -1,6 +1,6 @@
 /*
  RF24Server.cpp - Arduino implementation of a uIP wrapper class.
- Copyright (c) 2014 tmrh20@gmail.com, github.com/TMRh20 
+ Copyright (c) 2014 tmrh20@gmail.com, github.com/TMRh20
  Copyright (c) 2013 Norbert Truchsess <norbert.truchsess@t-online.de>
  All rights reserved.
 
@@ -20,8 +20,9 @@
 #include "RF24Ethernet.h"
 #include "RF24Server.h"
 
-extern "C" {
-  //#include "uip-conf.h"
+extern "C"
+{
+    //#include "uip-conf.h"
 }
 
 /*************************************************************/
@@ -34,43 +35,41 @@ RF24Server::RF24Server(uint16_t port) : _port(htons(port))
 
 RF24Client RF24Server::available()
 {
-  Ethernet.tick();
-  for ( uip_userdata_t* data = &RF24Client::all_data[0]; data < &RF24Client::all_data[UIP_CONNS]; data++ )
+    Ethernet.tick();
+    for (uip_userdata_t *data = &RF24Client::all_data[0]; data < &RF24Client::all_data[UIP_CONNS]; data++)
     {
-        if (data->packets_in != 0 && (((data->state & UIP_CLIENT_CONNECTED) && uip_conns[data->state & UIP_CLIENT_SOCKETS].lport ==_port)
-              || ((data->state & UIP_CLIENT_REMOTECLOSED) && ((uip_userdata_closed_t *)data)->lport == _port))){
-			  return RF24Client(data);
-		}
-    }	
-  return RF24Client();
+        if (data->packets_in != 0 && (((data->state & UIP_CLIENT_CONNECTED) && uip_conns[data->state & UIP_CLIENT_SOCKETS].lport == _port) || ((data->state & UIP_CLIENT_REMOTECLOSED) && ((uip_userdata_closed_t *)data)->lport == _port)))
+        {
+            return RF24Client(data);
+        }
+    }
+    return RF24Client();
 }
 
 /*************************************************************/
 
 void RF24Server::begin()
-{  
-  uip_listen(_port);
-  RF24Ethernet.tick();  
+{
+    uip_listen(_port);
+    RF24Ethernet.tick();
 }
 
 /*************************************************************/
 
 size_t RF24Server::write(uint8_t c)
 {
-  return write(&c,1);
+    return write(&c, 1);
 }
 
 /*************************************************************/
 
 size_t RF24Server::write(const uint8_t *buf, size_t size)
 {
-  size_t ret = 0;
-  for ( uip_userdata_t* data = &RF24Client::all_data[0]; data < &RF24Client::all_data[UIP_CONNS]; data++ )
+    size_t ret = 0;
+    for (uip_userdata_t *data = &RF24Client::all_data[0]; data < &RF24Client::all_data[UIP_CONNS]; data++)
     {
-      if ((data->state & UIP_CLIENT_CONNECTED) && uip_conns[data->state & UIP_CLIENT_SOCKETS].lport ==_port)
-        ret += RF24Client::_write(data,buf,size);
+        if ((data->state & UIP_CLIENT_CONNECTED) && uip_conns[data->state & UIP_CLIENT_SOCKETS].lport == _port)
+            ret += RF24Client::_write(data, buf, size);
     }
-  return ret;
+    return ret;
 }
-
-/*************************************************************/

--- a/RF24Server.h
+++ b/RF24Server.h
@@ -1,6 +1,6 @@
 /*
  RF24Server.h - Arduino implementation of a uIP wrapper class.
- Copyright (c) 2014 tmrh20@gmail.com, github.com/TMRh20 
+ Copyright (c) 2014 tmrh20@gmail.com, github.com/TMRh20
  Copyright (c) 2013 Norbert Truchsess <norbert.truchsess@t-online.de>
  All rights reserved.
  This program is free software: you can redistribute it and/or modify
@@ -18,7 +18,6 @@
 #ifndef RF24SERVER_H
 #define RF24SERVER_H
 
-
 #include "Server.h"
 #include "RF24Client.h"
 #include "ethernet_comp.h"
@@ -26,15 +25,15 @@
 class RF24Server : public Server {
 
 public:
-  RF24Server(uint16_t);
-  RF24Client available();
-  void begin();
-  size_t write(uint8_t);
-  size_t write(const uint8_t *buf, size_t size);
-  using Print::write;
+    RF24Server(uint16_t);
+    RF24Client available();
+    void begin();
+    size_t write(uint8_t);
+    size_t write(const uint8_t *buf, size_t size);
+    using Print::write;
 
 private:
-  uint16_t _port;
+    uint16_t _port;
 };
 
 #endif

--- a/RF24Udp.cpp
+++ b/RF24Udp.cpp
@@ -1,6 +1,6 @@
 /*
  RF24UDP.cpp - Arduino implementation of a uIP wrapper class.
- Copyright (c) 2014 tmrh20@gmail.com, github.com/TMRh20 
+ Copyright (c) 2014 tmrh20@gmail.com, github.com/TMRh20
  Copyright (c) 2013 Norbert Truchsess <norbert.truchsess@t-online.de>
  All rights reserved.
 
@@ -25,7 +25,6 @@
 #include "HardwareSerial.h"
 #endif
 
-
 #if UIP_UDP
 #define UIP_ARPHDRSIZE 42
 #define UDPBUF ((struct uip_udpip_hdr *)&uip_buf[UIP_LLH_LEN])
@@ -33,41 +32,45 @@
 /*******************************************************/
 
 // Constructor
-RF24UDP::RF24UDP() :
-    _uip_udp_conn(NULL)
+RF24UDP::RF24UDP() : _uip_udp_conn(NULL)
 {
-  memset(&appdata,0,sizeof(appdata));
+    memset(&appdata, 0, sizeof(appdata));
 }
 
 /*******************************************************/
 
 // initialize, start listening on specified port. Returns 1 if successful, 0 if there are no sockets available to use
-uint8_t RF24UDP::begin(uint16_t port) {
-  if (!_uip_udp_conn) {
-      _uip_udp_conn = uip_udp_new(NULL, 0);
-  }
-  if (_uip_udp_conn) {
-      uip_udp_bind(_uip_udp_conn,htons(port));
-      _uip_udp_conn->appstate = &appdata;
-      return 1;
-  }
-  return 0;
+uint8_t RF24UDP::begin(uint16_t port)
+{
+    if (!_uip_udp_conn)
+    {
+        _uip_udp_conn = uip_udp_new(NULL, 0);
+    }
+    if (_uip_udp_conn)
+    {
+        uip_udp_bind(_uip_udp_conn, htons(port));
+        _uip_udp_conn->appstate = &appdata;
+        return 1;
+    }
+    return 0;
 }
 
 /*******************************************************/
 
 // Finish with the UDP socket
-void RF24UDP::stop() {
-  if (_uip_udp_conn) {
-      uip_udp_remove(_uip_udp_conn);
-      _uip_udp_conn->appstate = NULL;
-      _uip_udp_conn=NULL;
-	  appdata.packet_in = 0;
-	  appdata.packet_next = 0;
-	  appdata.packet_out = 0;
-	  
-      memset(&appdata,0,sizeof(appdata));
-  }
+void RF24UDP::stop()
+{
+    if (_uip_udp_conn)
+    {
+        uip_udp_remove(_uip_udp_conn);
+        _uip_udp_conn->appstate = NULL;
+        _uip_udp_conn = NULL;
+        appdata.packet_in = 0;
+        appdata.packet_next = 0;
+        appdata.packet_out = 0;
+
+        memset(&appdata, 0, sizeof(appdata));
+    }
 }
 
 /*******************************************************/
@@ -76,254 +79,299 @@ void RF24UDP::stop() {
 
 // Start building up a packet to send to the remote host specific in ip and port
 // Returns 1 if successful, 0 if there was a problem with the supplied IP address or port
-int RF24UDP::beginPacket(IPAddress ip, uint16_t port){
-  RF24EthernetClass::tick();
-  if (ip && port) {
-      uip_ipaddr_t ripaddr;
-      uip_ip_addr(&ripaddr, ip);
-      IF_RF24ETHERNET_DEBUG_UDP( Serial.print(F("RF24UDP udp beginPacket, ")); );
+int RF24UDP::beginPacket(IPAddress ip, uint16_t port)
+{
+    RF24EthernetClass::tick();
+    if (ip && port)
+    {
+        uip_ipaddr_t ripaddr;
+        uip_ip_addr(&ripaddr, ip);
+        IF_RF24ETHERNET_DEBUG_UDP(Serial.print(F("RF24UDP udp beginPacket, ")););
 
-      if (_uip_udp_conn){
-          _uip_udp_conn->rport = htons(port);
-          uip_ipaddr_copy(_uip_udp_conn->ripaddr, &ripaddr);
-      }else{
-          _uip_udp_conn = uip_udp_new(&ripaddr,htons(port));
-          if (_uip_udp_conn) {
-              IF_RF24ETHERNET_DEBUG_UDP( Serial.print(F("RF24UDP New connection, ")); );
-              _uip_udp_conn->appstate = &appdata;
-          }else{
-              IF_RF24ETHERNET_DEBUG_UDP( Serial.println(F("RF24UDP Failed to allocate new connection")); );
-              return 0;
-          }
-      }
-          IF_RF24ETHERNET_DEBUG_UDP( Serial.print(F("rip: ")); Serial.print(ip); Serial.print(F(", port: ")); Serial.println(port); );
-  }
+        if (_uip_udp_conn)
+        {
+            _uip_udp_conn->rport = htons(port);
+            uip_ipaddr_copy(_uip_udp_conn->ripaddr, &ripaddr);
+        }
+        else
+        {
+            _uip_udp_conn = uip_udp_new(&ripaddr, htons(port));
+            if (_uip_udp_conn)
+            {
+                IF_RF24ETHERNET_DEBUG_UDP(Serial.print(F("RF24UDP New connection, ")););
+                _uip_udp_conn->appstate = &appdata;
+            }
+            else
+            {
+                IF_RF24ETHERNET_DEBUG_UDP(Serial.println(F("RF24UDP Failed to allocate new connection")););
+                return 0;
+            }
+        }
+        IF_RF24ETHERNET_DEBUG_UDP(Serial.print(F("rip: ")); Serial.print(ip); Serial.print(F(", port: ")); Serial.println(port););
+    }
 
-  if (_uip_udp_conn) {
-      if (appdata.packet_out == 0) {
-          appdata.packet_out = 1;
-          appdata.out_pos = 0;//UIP_UDP_PHYH_LEN;
-          if (appdata.packet_out != 0){
-            return 1;          
-		  }else{
-		    IF_RF24ETHERNET_DEBUG_UDP( Serial.println(F("RF24UDP Failed to allocate memory for packet")); );
-          }
-	  }else{
-	    IF_RF24ETHERNET_DEBUG_UDP( Serial.println(F("RF24UDP Previous packet on that connection not sent yet")); );
-	  }
-  }
-  return 0;
+    if (_uip_udp_conn)
+    {
+        if (appdata.packet_out == 0)
+        {
+            appdata.packet_out = 1;
+            appdata.out_pos = 0; //UIP_UDP_PHYH_LEN;
+            if (appdata.packet_out != 0)
+            {
+                return 1;
+            }
+            else
+            {
+                IF_RF24ETHERNET_DEBUG_UDP(Serial.println(F("RF24UDP Failed to allocate memory for packet")););
+            }
+        }
+        else
+        {
+            IF_RF24ETHERNET_DEBUG_UDP(Serial.println(F("RF24UDP Previous packet on that connection not sent yet")););
+        }
+    }
+    return 0;
 }
 
 /*******************************************************/
 
 // Start building up a packet to send to the remote host specific in host and port
 // Returns 1 if successful, 0 if there was a problem resolving the hostname or port
-int RF24UDP::beginPacket(const char *host, uint16_t port) {
-  // Look up the host first
-  int ret = 0;
-  DNSClient dns;
-  IPAddress remote_addr;
+int RF24UDP::beginPacket(const char *host, uint16_t port)
+{
+    // Look up the host first
+    int ret = 0;
+    DNSClient dns;
+    IPAddress remote_addr;
 
-  dns.begin(RF24Ethernet.dnsServerIP());
-  ret = dns.getHostByName(host, remote_addr);
-  if (ret == 1) {
-    return beginPacket(remote_addr, port);
-  } else {
-    return ret;
-  }
+    dns.begin(RF24Ethernet.dnsServerIP());
+    ret = dns.getHostByName(host, remote_addr);
+    if (ret == 1)
+    {
+        return beginPacket(remote_addr, port);
+    }
+    else
+    {
+        return ret;
+    }
 }
 
 /*******************************************************/
 
 // Finish off this packet and send it
 // Returns 1 if the packet was sent successfully, 0 if there was an error
-int RF24UDP::endPacket() {
-  if (_uip_udp_conn && appdata.packet_out != 0) {
-      appdata.send = true;
-	  IF_RF24ETHERNET_DEBUG_UDP( Serial.println(F("RF24UDP endpacket")); );
-      uip_udp_periodic_conn(_uip_udp_conn);
-      if (uip_len > 0) {
-          _send(&appdata);
-          return 1;
+int RF24UDP::endPacket()
+{
+    if (_uip_udp_conn && appdata.packet_out != 0)
+    {
+        appdata.send = true;
+        IF_RF24ETHERNET_DEBUG_UDP(Serial.println(F("RF24UDP endpacket")););
+        uip_udp_periodic_conn(_uip_udp_conn);
+        if (uip_len > 0)
+        {
+            _send(&appdata);
+            return 1;
         }
-  }
-  return 0;
+    }
+    return 0;
 }
 
 /*******************************************************/
 
 // Write a single byte into the packet
-size_t RF24UDP::write(uint8_t c) {
-  return write(&c,1);
+size_t RF24UDP::write(uint8_t c)
+{
+    return write(&c, 1);
 }
 
 /*******************************************************/
 
 // Write size bytes from buffer into the packet
-size_t RF24UDP::write(const uint8_t *buffer, size_t size) {
-  if (appdata.packet_out != 0) {
-	
-	  IF_RF24ETHERNET_DEBUG_UDP( Serial.println("RF24UDP Write: "); Serial.println(size); for(int i=0; i<size; i++){ Serial.print((char)buffer[i]); Serial.print(" "); } Serial.println(""); );
-	  size_t ret = size;
-	  memcpy(RF24Client::all_data[0].myData + appdata.out_pos ,buffer,size);
-      appdata.out_pos += ret;
-      return ret;
-  }
-  return 0;
+size_t RF24UDP::write(const uint8_t *buffer, size_t size)
+{
+    if (appdata.packet_out != 0)
+    {
+        IF_RF24ETHERNET_DEBUG_UDP(Serial.println("RF24UDP Write: "); Serial.println(size); for (int i = 0; i < size; i++) { Serial.print((char)buffer[i]); Serial.print(" "); } Serial.println(""););
+        size_t ret = size;
+        memcpy(RF24Client::all_data[0].myData + appdata.out_pos, buffer, size);
+        appdata.out_pos += ret;
+        return ret;
+    }
+    return 0;
 }
 
 /*******************************************************/
 
 // Start processing the next available incoming packet
 // Returns the size of the packet in bytes, or 0 if no packets are available
-int RF24UDP::parsePacket() {
+int RF24UDP::parsePacket()
+{
 
-  RF24EthernetClass::tick();
-  int size = appdata.packet_in_size;
-  
-  IF_RF24ETHERNET_DEBUG_UDP( if (appdata.packet_in != 0) { Serial.print(F("RF24UDP udp parsePacket freeing previous packet: ")); Serial.println(appdata.packet_in); } );
+    RF24EthernetClass::tick();
+    int size = appdata.packet_in_size;
 
-  //appdata.packet_in_size = 0;
-  
-  //appdata.packet_in = appdata.packet_next;
-  //appdata.packet_next = 0;
+    IF_RF24ETHERNET_DEBUG_UDP(if (appdata.packet_in != 0) { Serial.print(F("RF24UDP udp parsePacket freeing previous packet: ")); Serial.println(appdata.packet_in); });
 
-  IF_RF24ETHERNET_DEBUG_UDP( if (appdata.packet_in != 0) { Serial.print(F("RF24UDP udp parsePacket received packet: ")); Serial.print(appdata.packet_in); } Serial.print(F(", size: ")); Serial.println(size); );
-  
-  return size;
+    //appdata.packet_in_size = 0;
+
+    //appdata.packet_in = appdata.packet_next;
+    //appdata.packet_next = 0;
+
+    IF_RF24ETHERNET_DEBUG_UDP(if (appdata.packet_in != 0) { Serial.print(F("RF24UDP udp parsePacket received packet: ")); Serial.print(appdata.packet_in); } Serial.print(F(", size: ")); Serial.println(size););
+
+    return size;
 }
 
 /*******************************************************/
 
 // Number of bytes remaining in the current packet
-int RF24UDP::available() {
-  RF24EthernetClass::tick();
-  return appdata.packet_in_size;
+int RF24UDP::available()
+{
+    RF24EthernetClass::tick();
+    return appdata.packet_in_size;
 }
 
 /*******************************************************/
 
 // Read a single byte from the current packet
-int RF24UDP::read() {
-  unsigned char c;
-  if (read(&c,1) > 0) {
-      return c;
-  }
-  return -1;
+int RF24UDP::read()
+{
+    unsigned char c;
+    if (read(&c, 1) > 0)
+    {
+        return c;
+    }
+    return -1;
 }
 
 /*******************************************************/
 
 // Read up to len bytes from the current packet and place them into buffer
 // Returns the number of bytes read, or 0 if none are available
-int RF24UDP::read(unsigned char* buffer, size_t len) {
-  
-  RF24EthernetClass::tick();
-  
-  if (appdata.packet_in != 0) {
-	  memcpy(buffer,RF24Client::all_data[0].myDataIn + appdata.in_pos,len);
-	  appdata.in_pos += len;
-	  appdata.packet_in_size -= len;
-	  
-      if (appdata.packet_in_size < 1) {
-          appdata.packet_in = 0;
-      }
-      return len;
-  }
-  return 0;
+int RF24UDP::read(unsigned char *buffer, size_t len)
+{
+
+    RF24EthernetClass::tick();
+
+    if (appdata.packet_in != 0)
+    {
+        memcpy(buffer, RF24Client::all_data[0].myDataIn + appdata.in_pos, len);
+        appdata.in_pos += len;
+        appdata.packet_in_size -= len;
+
+        if (appdata.packet_in_size < 1)
+        {
+            appdata.packet_in = 0;
+        }
+        return len;
+    }
+    return 0;
 }
 
 /*******************************************************/
 
 // Return the next byte from the current packet without moving on to the next byte
-int RF24UDP::peek() {
+int RF24UDP::peek()
+{
 
-  RF24EthernetClass::tick();
+    RF24EthernetClass::tick();
 
-  if (appdata.packet_in != 0) {
-      return RF24Client::all_data[0].myDataIn[appdata.in_pos];
-  }
-  return -1;
+    if (appdata.packet_in != 0)
+    {
+        return RF24Client::all_data[0].myDataIn[appdata.in_pos];
+    }
+    return -1;
 }
 
 /*******************************************************/
 
 // Finish reading the current packet
-void RF24UDP::flush() {
-  appdata.packet_in = 0;
-  appdata.packet_in_size = 0;
-  RF24EthernetClass::tick();
+void RF24UDP::flush()
+{
+    appdata.packet_in = 0;
+    appdata.packet_in_size = 0;
+    RF24EthernetClass::tick();
 }
 
 /*******************************************************/
 
 // Return the IP address of the host who sent the current incoming packet
-IPAddress RF24UDP::remoteIP() {
-  return _uip_udp_conn ? ip_addr_uip(_uip_udp_conn->ripaddr) : IPAddress();
+IPAddress RF24UDP::remoteIP()
+{
+    return _uip_udp_conn ? ip_addr_uip(_uip_udp_conn->ripaddr) : IPAddress();
 }
 
 /*******************************************************/
 
 // Return the port of the host who sent the current incoming packet
-uint16_t RF24UDP::remotePort() {
-  return _uip_udp_conn ? ntohs(_uip_udp_conn->rport) : 0;
+uint16_t RF24UDP::remotePort()
+{
+    return _uip_udp_conn ? ntohs(_uip_udp_conn->rport) : 0;
 }
 
 /*******************************************************/
 
 // uIP callback function
 
-void uipudp_appcall(void) {
-  if (uip_udp_userdata_t *data = (uip_udp_userdata_t *)(uip_udp_conn->appstate)) {
-      if (uip_newdata()) {
-          if (data->packet_next == 0) {
-              uip_udp_conn->rport = UDPBUF->srcport;
-              uip_ipaddr_copy(uip_udp_conn->ripaddr,UDPBUF->srcipaddr);
-			  
-              //discard Linklevel and IP and udp-header and any trailing bytes:
-			  memcpy(RF24Client::all_data[0].myDataIn,uip_appdata ,uip_len);
-			  data->packet_in_size += uip_len;
-			  data->packet_in = 1;
-              
-              IF_RF24ETHERNET_DEBUG_UDP( Serial.print(F("RF24UDP udp, uip_newdata received packet: ")); Serial.print(data->packet_next); Serial.print(F(", size: ")); Serial.println(data->packet_in_size); for(int i=0; i<data->packet_in_size; i++){  Serial.print(RF24Client::all_data[0].myDataIn[i],HEX); Serial.print(F(" : "));  } Serial.println();  );
-          }
-      }
-      if (uip_poll() && data->send) {
-          //set uip_slen (uip private) by calling uip_udp_send
-          IF_RF24ETHERNET_DEBUG_UDP(Serial.print(F("udp, uip_poll preparing packet to send: ")); Serial.print(data->packet_out); Serial.print(F(", size: ")); Serial.println(data->out_pos);  );
-		  
-		  memcpy(uip_appdata,RF24Client::all_data[0].myData,data->out_pos);
-          uip_udp_send(data->out_pos );
+void uipudp_appcall(void)
+{
+    if (uip_udp_userdata_t *data = (uip_udp_userdata_t *)(uip_udp_conn->appstate))
+    {
+        if (uip_newdata())
+        {
+            if (data->packet_next == 0)
+            {
+                uip_udp_conn->rport = UDPBUF->srcport;
+                uip_ipaddr_copy(uip_udp_conn->ripaddr, UDPBUF->srcipaddr);
+
+                //discard Linklevel and IP and udp-header and any trailing bytes:
+                memcpy(RF24Client::all_data[0].myDataIn, uip_appdata, uip_len);
+                data->packet_in_size += uip_len;
+                data->packet_in = 1;
+
+                IF_RF24ETHERNET_DEBUG_UDP(Serial.print(F("RF24UDP udp, uip_newdata received packet: ")); Serial.print(data->packet_next); Serial.print(F(", size: ")); Serial.println(data->packet_in_size); for (int i = 0; i < data->packet_in_size; i++) {  Serial.print(RF24Client::all_data[0].myDataIn[i],HEX); Serial.print(F(" : ")); } Serial.println(););
+            }
+        }
+        if (uip_poll() && data->send)
+        {
+            //set uip_slen (uip private) by calling uip_udp_send
+            IF_RF24ETHERNET_DEBUG_UDP(Serial.print(F("udp, uip_poll preparing packet to send: ")); Serial.print(data->packet_out); Serial.print(F(", size: ")); Serial.println(data->out_pos););
+
+            memcpy(uip_appdata, RF24Client::all_data[0].myData, data->out_pos);
+            uip_udp_send(data->out_pos);
         }
     }
 }
 
 /*******************************************************/
 
-void RF24UDP::_send(uip_udp_userdata_t *data) {
-  #if defined (RF24_TAP)
-  uip_arp_out(); //add arp
-  #endif
-  if (uip_len == UIP_ARPHDRSIZE) {
-      //RF24EthernetClass::uip_packet = 0;
-      //RF24EthernetClass::packetstate &= ~UIPETHERNET_SENDPACKET;
+void RF24UDP::_send(uip_udp_userdata_t *data)
+{
+#if defined(RF24_TAP)
+    uip_arp_out(); //add arp
+#endif
+    if (uip_len == UIP_ARPHDRSIZE)
+    {
+        //RF24EthernetClass::uip_packet = 0;
+        //RF24EthernetClass::packetstate &= ~UIPETHERNET_SENDPACKET;
 
-      IF_RF24ETHERNET_DEBUG_UDP(  Serial.println(F("udp, uip_poll results in ARP-packet")); );
-	  RF24EthernetClass::network_send();
-  }else{
-  //arp found ethaddr for ip (otherwise packet is replaced by arp-request)
-      data->send = false;
-      data->packet_out = 0;
-      //RF24EthernetClass::packetstate |= UIPETHERNET_SENDPACKET;
-      IF_RF24ETHERNET_DEBUG_UDP( Serial.println(data->out_pos); Serial.print(F("udp, uip_packet to send: ")); for(int i=0; i<data->out_pos; i++){  Serial.print((char)RF24Client::all_data[0].myData[i]);  }  Serial.println("");  );
-	  
-      RF24NetworkHeader headerOut(00,EXTERNAL_DATA_TYPE);  
-      RF24Ethernet.network.write(headerOut,uip_buf,data->out_pos+UIP_UDP_PHYH_LEN);
-  }
+        IF_RF24ETHERNET_DEBUG_UDP(Serial.println(F("udp, uip_poll results in ARP-packet")););
+        RF24EthernetClass::network_send();
+    }
+    else
+    {
+        //arp found ethaddr for ip (otherwise packet is replaced by arp-request)
+        data->send = false;
+        data->packet_out = 0;
+        //RF24EthernetClass::packetstate |= UIPETHERNET_SENDPACKET;
+        IF_RF24ETHERNET_DEBUG_UDP(Serial.println(data->out_pos); Serial.print(F("udp, uip_packet to send: ")); for (int i = 0; i < data->out_pos; i++) { Serial.print((char)RF24Client::all_data[0].myData[i]); } Serial.println(""););
+
+        RF24NetworkHeader headerOut(00, EXTERNAL_DATA_TYPE);
+        RF24Ethernet.network.write(headerOut, uip_buf, data->out_pos + UIP_UDP_PHYH_LEN);
+    }
 }
 
 /*******************************************************/
 
-#endif
-#endif
+#endif // UIP_UDP
+#endif // UDP Enabled

--- a/RF24Udp.h
+++ b/RF24Udp.h
@@ -1,6 +1,6 @@
 /*
  RF24Udp.h - Arduino implementation of a uIP wrapper class.
- Copyright (c) 2014 tmrh20@gmail.com, github.com/TMRh20 
+ Copyright (c) 2014 tmrh20@gmail.com, github.com/TMRh20
  Copyright (c) 2013 Norbert Truchsess <norbert.truchsess@t-online.de>
  All rights reserved.
 
@@ -16,7 +16,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
- 
+
  Updated for RF24Ethernet, TMRh20 2014-2015
  */
 
@@ -34,101 +34,110 @@
 #define UIP_UDP_MAXPACKETSIZE UIP_UDP_MAXDATALEN+UIP_UDP_PHYH_LEN
 
 typedef struct {
-  uint16_t out_pos;
-  uint8_t packet_next;
-  uint8_t packet_in;
-  uint8_t packet_out;
-  int packet_in_size;
-  uint16_t in_pos;
-  boolean send;
+    uint16_t out_pos;
+    uint8_t packet_next;
+    uint8_t packet_in;
+    uint8_t packet_out;
+    int packet_in_size;
+    uint16_t in_pos;
+    boolean send;
 } uip_udp_userdata_t;
 
 class RF24UDP : public UDP
 {
-
 private:
-  struct uip_udp_conn *_uip_udp_conn;
+    struct uip_udp_conn *_uip_udp_conn;
 
-  uip_udp_userdata_t appdata;
+    uip_udp_userdata_t appdata;
 
 public:
-  RF24UDP();  /**< Constructor */
-  uint8_t
-  begin(uint16_t); /**< initialize, start listening on specified port. Returns 1 if successful, 0 if there are no sockets available to use   */
-  void
-  stop();  /**< Finish with the UDP socket   */
+    /** @brief Constructor */
+    RF24UDP();
 
-  /** Sending UDP packets
-   *
-   * Start building up a packet to send to the remote host specific in ip and port
-   * @return 1 if successful, 0 if there was a problem with the supplied IP address or port
-   */
-  int beginPacket(IPAddress ip, uint16_t port);
-  
-  /** Start building up a packet to send to the remote host specific in host and port
-  * @return 1 if successful, 0 if there was a problem resolving the hostname or port
-  */
-  int  beginPacket(const char *host, uint16_t port);
-  
-  /** Finish off this packet and send it
-   * @return 1 if the packet was sent successfully, 0 if there was an error
-   */
-  int  endPacket();
-  
-  /** Write a single byte into the packet
-   */
-  size_t write(uint8_t);
-  
-  /** Write size bytes from buffer into the packet
-  */
-  size_t write(const uint8_t *buffer, size_t size);
+    /**
+     * @brief initialize, start listening on specified port.
+     * @returns 1 if successful, 0 if there are no sockets available to use
+     */
+    uint8_t begin(uint16_t);
 
-  using Print::write;
+    /** @brief Finish with the UDP socket */
+    void stop();
 
-  /** Start processing the next available incoming packet
-   * @return The size of the packet in bytes, or 0 if no packets are available
-  */
-  int parsePacket();
-  
-  /** Number of bytes remaining in the current packet */
-  int available();
-  
-  /** Read a single byte from the current packet */
-  int read();
-  
-  /** Read up to len bytes from the current packet and place them into buffer
-   * @return The number of bytes read, or 0 if none are available
-   */
-  int read(unsigned char* buffer, size_t len);
-  
-  /** Read up to len characters from the current packet and place them into buffer
-   * @ return The number of characters read, or 0 if none are available
-   */
-  int read(char* buffer, size_t len) {
-    return read((unsigned char*) buffer, len);
-  };
-  
-  /** @return The next byte from the current packet without moving on to the next byte */
-  int peek();
-  
-  void flush();	/** < Finish reading the current packet  */
+    /**
+     * @brief Sending UDP packets
+     *
+     * Start building up a packet to send to the remote host specific in ip and port
+     * @return 1 if successful, 0 if there was a problem with the supplied IP address or port
+     */
+    int beginPacket(IPAddress ip, uint16_t port);
 
-  /** Return the IP address of the host who sent the current incoming packet */
-  IPAddress remoteIP();
+    /**
+     * Start building up a packet to send to the remote host specific in host and port
+     * @return 1 if successful, 0 if there was a problem resolving the hostname or port
+     */
+    int beginPacket(const char *host, uint16_t port);
 
-  /** Return the port of the host who sent the current incoming packet */
-  uint16_t remotePort();
+    /**
+     * @brief Finish off this packet and send it
+     * @return 1 if the packet was sent successfully, 0 if there was an error
+     */
+    int endPacket();
+
+    /** @brief Write a single byte into the packet */
+    size_t write(uint8_t);
+
+    /** @brief Write @p size bytes from @p buffer into the packet */
+    size_t write(const uint8_t *buffer, size_t size);
+
+    using Print::write;
+
+    /**
+     * Start processing the next available incoming packet
+     * @return The size of the packet in bytes, or 0 if no packets are available
+     */
+    int parsePacket();
+
+    /** Number of bytes remaining in the current packet */
+    int available();
+
+    /** Read a single byte from the current packet */
+    int read();
+
+    /**
+     * Read up to @p len bytes from the current packet and place them into @p buffer
+     * @return The number of bytes read, or 0 if none are available
+     */
+    int read(unsigned char* buffer, size_t len);
+
+    /**
+     * Read up to @p len characters from the current packet and place them into @p buffer
+     * @return The number of characters read, or 0 if none are available
+     */
+    int read(char* buffer, size_t len) {
+        return read((unsigned char*) buffer, len);
+    };
+
+    /** @return The next byte from the current packet without moving on to the next byte */
+    int peek();
+
+    /** < Finish reading the current packet  */
+    void flush();
+
+    /** Return the IP address of the host who sent the current incoming packet */
+    IPAddress remoteIP();
+
+    /** Return the port of the host who sent the current incoming packet */
+    uint16_t remotePort();
 
 private:
 
-  friend void uipudp_appcall(void);
+    friend void uipudp_appcall(void);
 
-  friend class RF24EthernetClass;
-  friend class RF24Client;
-  static void _send(uip_udp_userdata_t *data);
+    friend class RF24EthernetClass;
+    friend class RF24Client;
+    static void _send(uip_udp_userdata_t *data);
 
 };
 
-#endif
-
 #endif // UDP Enabled
+#endif // UIPUDP_H

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,1 @@
+These markdown files (*.md) contain relative hyperlinks. Any relative hyperlinks will not work when viewing these markdown files in github.

--- a/docs/config_setup.md
+++ b/docs/config_setup.md
@@ -6,14 +6,20 @@ See [this video walk-through](https://www.youtube.com/watch?v=rBAIqAaRu0g) of th
 
 ### Raspberry Pi
 On the Raspberry Pi, a companion program, <a href="http://nRF24.github.io/RF24Gateway/">RF24Gateway</a> must be installed along with the RF24 and RF24Network libraries
-1. ``` wget http://tmrh20.github.io/RF24Installer/RPi/install.sh ```
-2. ``` chmod +x install.sh ```
-3. ``` ./install.sh ```
-4. ``` cd RF24Gateway/examples/ncurses ```
-5. ``` make ```
-6. ``` sudo ./RF24Gateway_ncurses ```
-7. The application will require the user to specify an IP address and Subnet Mask: 10.10.2.2 and 255.255.255.0 are the defaults with RF24Ethernet examples
-8. Raspberry Pi defaults to the master node (00) using RF24Mesh. Secondary Raspberry pi nodes need to specify their RF24Network address or RF24Mesh nodeID.
+1. Enter the following to download an install script that will build and install the needed RF24* libraries:
+   ```shell
+   wget http://tmrh20.github.io/RF24Installer/RPi/install.sh
+   chmod +x install.sh
+   ./install.sh
+   ```
+2. Next, build and run the [RF24Gateway_ncurses example](https://nrf24.github.io/RF24Gateway/RF24Gateway_ncurses_8cpp-example.html)
+   ```shell
+   cd RF24Gateway/examples/ncurses
+   make
+   sudo ./RF24Gateway_ncurses
+   ```
+3. The application will require the user to specify an IP address and Subnet Mask: 10.10.2.2 and 255.255.255.0 are the defaults with RF24Ethernet examples
+4. Raspberry Pi defaults to the master node (00) using RF24Mesh. Secondary Raspberry pi nodes need to specify their RF24Network address or RF24Mesh nodeID.
 
 ### Arduino
 1. For Arduino devices, use the Arduino Library Manager to install the RF24 libraries
@@ -24,7 +30,7 @@ On the Raspberry Pi, a companion program, <a href="http://nRF24.github.io/RF24Ga
 6. Connect into your nodes web-server at `http://ip-of-your-node:1000` from the RPi or configure the client sketch to connect to a server
 running on the Raspberry Pi.
 
-Note: To minimize memory usage on Arduino, edit RF24Network_config.h with a text editor, and uncomment `#define DISABLE_USER_PAYLOADS`. This
+@note To minimize memory usage on Arduino, edit RF24Network_config.h with a text editor, and uncomment `#define DISABLE_USER_PAYLOADS`. This
 will disable standard RF24Network messages, and only allow external data, such as TCP/IP information. Remember to comment for normal operation!
 
 ### Non-Raspberry Pi (Linux etc) Devices
@@ -35,8 +41,16 @@ examples for usage without the need for a Raspberry Pi.
 ### Accessing External Systems: Forwarding and Routing
 In order to give your network or nodes access to your network or the internet beyond the RPi, it needs to be configured to route traffic
 between the networks.
-1. Run `sudo sysctl -w net.ipv4.ip_forward=1` to allow the RPi to forward requests between the network interfaces
-2. `sudo iptables -t nat -A POSTROUTING -j MASQUERADE` to allow the RPi to perform NAT between the network interfaces <br>
+1. Run
+   ```shell
+   sudo sysctl -w net.ipv4.ip_forward=1
+   ```
+   to allow the RPi to forward requests between the network interfaces
+2. Run
+   ```shell
+   sudo iptables -t nat -A POSTROUTING -j MASQUERADE
+   ```
+   to allow the RPi to perform NAT between the network interfaces
 
 @note This configuration is generally for initial testing only. Users may also need to add a static route to their local machine, or configure port forwarding on the RPi.<br>
 See the following links for more information on configuring and using IPTables:<br>

--- a/docs/config_setup.md
+++ b/docs/config_setup.md
@@ -1,0 +1,49 @@
+# Configuration and Set-Up
+RF24Ethernet requires the RF24 and RF24Network libraries (optionally RF24Mesh) <br>
+See http://tmrh20.github.io for documentation and downloads
+
+See [this video walk-through](https://www.youtube.com/watch?v=rBAIqAaRu0g) of the software setup with Raspberry Pi and Arduino.
+
+### Raspberry Pi
+On the Raspberry Pi, a companion program, <a href="http://nRF24.github.io/RF24Gateway/">RF24Gateway</a> must be installed along with the RF24 and RF24Network libraries
+1. ``` wget http://tmrh20.github.io/RF24Installer/RPi/install.sh ```
+2. ``` chmod +x install.sh ```
+3. ``` ./install.sh ```
+4. ``` cd RF24Gateway/examples/ncurses ```
+5. ``` make ```
+6. ``` sudo ./RF24Gateway_ncurses ```
+7. The application will require the user to specify an IP address and Subnet Mask: 10.10.2.2 and 255.255.255.0 are the defaults with RF24Ethernet examples
+8. Raspberry Pi defaults to the master node (00) using RF24Mesh. Secondary Raspberry pi nodes need to specify their RF24Network address or RF24Mesh nodeID.
+
+### Arduino
+1. For Arduino devices, use the Arduino Library Manager to install the RF24 libraries
+2. Open the included Getting_Started_SimpleServer or Getting_Started_SimpleClient example
+3. Configure your chosen CE and CS pins for the radio connection.
+4. Configure the RF24Mesh nodeID (Any unique value from 3 to 255)
+5. Configure the IP address according to your preferences, (last octet must==nodeID) with the gateway set to the chosen IP of the RPi.
+6. Connect into your nodes web-server at `http://ip-of-your-node:1000` from the RPi or configure the client sketch to connect to a server
+running on the Raspberry Pi.
+
+Note: To minimize memory usage on Arduino, edit RF24Network_config.h with a text editor, and uncomment `#define DISABLE_USER_PAYLOADS`. This
+will disable standard RF24Network messages, and only allow external data, such as TCP/IP information. Remember to comment for normal operation!
+
+### Non-Raspberry Pi (Linux etc) Devices
+Arduino can also function as a gateway for any Linux machine or PC/MAC that supports SLIP. <br>
+See the SLIP_Gateway and SLIP_InteractiveServer
+examples for usage without the need for a Raspberry Pi.
+
+### Accessing External Systems: Forwarding and Routing
+In order to give your network or nodes access to your network or the internet beyond the RPi, it needs to be configured to route traffic
+between the networks.
+1. Run `sudo sysctl -w net.ipv4.ip_forward=1` to allow the RPi to forward requests between the network interfaces
+2. `sudo iptables -t nat -A POSTROUTING -j MASQUERADE` to allow the RPi to perform NAT between the network interfaces <br>
+
+@note This configuration is generally for initial testing only. Users may also need to add a static route to their local machine, or configure port forwarding on the RPi.<br>
+See the following links for more information on configuring and using IPTables:<br>
+http://www.karlrupp.net/en/computer/nat_tutorial<br>
+http://serverfault.com/questions/326493/basic-iptables-nat-port-forwarding
+
+@warning **Note:** Users are responsible to manage further routing rules along with their IP traffic in order to prevent unauthorized access.
+
+## Advanced (uIP) Configuration and Info
+See the [User Configuration](group__UipConfiguration.html) section for modifying uip-conf.h

--- a/docs/custom_networks.md
+++ b/docs/custom_networks.md
@@ -1,0 +1,37 @@
+# Building an RF24Ethernet Network
+The general configuration instructions set up a basic sensor network, with static nodes, using TCP/IP over RF24Network. The layered
+library design also allows some nodes to communicate solely at the RF24Network level, creating hybrid networks to extend range over
+large distances, or improve connectivity in distant areas.
+
+## RF24Mesh Networks
+RF24Mesh allows dynamic configuration of RF24Network addresses, and allows the creation of dynamic sensor networks. Nodes are able
+to move around physically, releasing and renewing their RF24Network address as required. Once configured with a unique nodeID, nodes using RF24Mesh
+can automatically configure themselves and join the network as required, with no user interaction.
+
+See the included [SimpleServer_Mesh](SimpleServer_mesh_8ino-example.html) example for general usage and configuration information
+with RF24Ethernet.
+
+### RF24Mesh - Additional Information
+When utilizing RF24Mesh along with RF24Ethernet, relay/routing nodes should be configured with RF24Mesh, or designated on the master node as static nodes
+with a pre-configured RF24Network address.
+
+RF24Mesh can be used with TAP/Ethernet configurations, but utilizing TUN/RF24Mesh together will reduce overhead.
+
+See the links below for more information on utilizing RF24Mesh with RF24Ethernet and RF24Network.
+
+## RF24Gateway
+See http://nRF24.github.io/RF24Gateway/ for more information on RF24Gateway
+
+## Hybrid- RF24Network/RF24Ethernet Networks
+The default configuration of RF24Ethernet and RF24Network enables both TCP/IP and the underlying messaging protocols provided by RF24Network.
+
+Relay/Routing nodes can be configured using only the RF24 and RF24Network layers (optionally RF24Mesh), and will automatically handle data
+accordingly, whether it is an external data type (TCP/IP) or an internal network message from another RF24Network node. This allows very small and
+inexpensive devices such as ATTiny to act as relay/routing nodes when extending network range and/or connectivity.
+
+Arduino/AVR devices can utilize custom or included sleep modes in RF24Network, and benefit from the lower power consumption and low-power features
+of the nrf24l01 chips directly.
+
+## Links
+See http://nRF24.github.io/RF24Mesh for more information on using RF24Mesh to create a dynamic network, with automatic RF24Network addressing <br>
+See http://nRF24.github.io/RF24Network for more information on using RF24Network as well as addressing and topology.

--- a/docs/main_page.md
+++ b/docs/main_page.md
@@ -1,0 +1,37 @@
+# RF24Ethernet library: TCP/IP over RF24Network
+
+## Open & Open-Source IoT Wireless (not WiFi) Networks
+**An experiment disconnected...**
+
+![
+    @image html images/RF24EthernetOverviewImg.jpg width=70% height=70%
+    ](https://github.com/nRF24/RF24Ethernet/blob/master/images/RF24EthernetOverviewImg.jpg)
+
+## Goals
+- Bring the reliability of TCP/IP and potential of mesh networking/IoT to even the smallest of Arduino devices
+- Enable self-sustaining wireless sensor networks that seamlessly link together using standard protocols & networking
+- Simplify & automate it.
+- Experiment with/document a model for completely open & open-source communication
+
+## News
+See the releases' descriptions on
+[the library's release page](http://github.com/nRF24/RF24Ethernet/releases) for a list of
+changes.
+
+See [version history](md_docs_pre_nrf24_changelog.html) for more about the lineage of RF24Ethernet.
+
+## Configuration and Setup
+The hardest part of setting up is getting the first radio module connected properly. <br>
+Scroll to the bottom of the [RF24 radio documentation for pin connections](http://nRF24.github.io/RF24/) <br><br>
+Once you have done that, see the [Configuration and Set-Up](md_docs_config_setup.html) page for general installation and configuration information
+
+## Detailed Overview
+See the [**Overview**](md_docs_overview.html) page
+
+## Building a Network - Customizing your RF24 TCP/IP network
+See the [Building a network](md_docs_custom_networks.html) page
+
+## About Troubleshooting
+The RF24 libraries are divided into layers, generally according to the OSI model, which allows specialized testing and troubleshooting of individual layers.
+
+See the [Troubleshooting section](md_docs_troubleshooting.html) for general troubleshooting steps.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,64 @@
+# RF24EthernetOverview RF24Ethernet Overview
+
+## Overview
+The RF24Ethernet library was initially designed as an experiment and potential testing tool for [RF24Network](http://nRF24.github.io/RF24Network), an OSI Layer 3 network driver, allowing a Raspberry Pi to
+act as a TCP/IP gateway or host for connected sensor nodes. An Arduino can interface with any Linux machine or SLIP capable device supporting USB, or
+preferably, an RPi runs companion software, [RF24Gateway](http://nRF24.github.io/RF24Gateway/), which creates a network interface linked to the RF24 radio network. This interface can be
+further linked to the local network or internet. This allows the RPi or Arduino-based gateway to perform automatic discovery and routing of TCP/IP data,
+with no required pre-configuration or interaction from the user beyond assigning appropriate addresses to the nodes initially.
+
+## What does it do?
+RF24Ethernet creates a network of internet enabled RF24/Arduino sensors. It provides an API and interface very similar to the Arduino Ethernet library,
+to allow sensor nodes to connect out to local or internet based devices to retrieve or send information, or be connected to from the internet or your
+local network directly.
+
+Sensor nodes can act as individual web servers, simple command-and-control servers, or can connect out as required via TCP/IP.
+
+
+## How does it work?
+RF24Ethernet utilizes the UIP TCP/IP stack, allowing Arduino devices to use a Raspberry Pi running [RF24Gateway](http://nRF24.github.io/RF24Gateway/) or Arduino
+as a gateway to your network or the internet, or simply as a repository for sensor information. The RF24, RF24Network and optionally RF24Mesh libraries
+handle the underlying routing, addressing etc. so users do not need to be familiar with the radio modules or libraries.
+
+RF24Network addresses need to be assigned as MAC addresses, and IP addresses can be configured as desired by the user. The master node (00) uses
+either the Address Resolution Protocol (ARP) or RF24Mesh to find the appropriate nodes when IP traffic is sent though, and routes traffic to the correct
+RF24Network address.
+
+This provides a fairly seamless interaction, since users only need to configure standard IP forwarding and firewall rules as desired.
+
+The RF24 libraries are based on the [OSI model](http://en.wikipedia.org/wiki/OSI_model):
+
+| System                 | OSI Layer              | Description |
+|------------------------|------------------------|---------------------------------------------------------------------------|
+| <b>NRF24L01 Radio Modules</b> | OSI Layer 1 (Physical)   | Transmission and reception of the raw bit stream over the physical medium. |
+| <b>RF24 Core Radio Driver</b> | OSI Layer 2 (Data Link)  | Transfer of data frames over the physical link. Establish/Terminate logical links between nodes. Manage acknowledgements, error checking |
+| <b>RF24Network</b>            | OSI Layer 3 (Network)    | Routing, subnets, subnet traffic control, logical-to-physical address mapping, frame fragmentation/reassembly.|
+| <b>RF24Ethernet (uIP)</b>     | OSI Layer 4 (Transport)  | Ensures error-free messages. Manages sequencing, losses, retries, and duplicates. |
+| <b>RF24Ethernet (core)</b>    | OSI Layer 5 (Session)    | Establish, maintain, and terminate connections |
+| <b>RF24Mesh</b> -Optional-    | OSI Layer 7 (Application)| Provides DHCP/DNS type protocols and allows dynamic addressing/topology for RF24Network.
+
+### TAP vs TUN
+RF24Ethernet and RF24Gateway are able to utilize both TAP and TUN type interfaces.
+
+#### TAP
+A TAP interface can be looked at much the same as an Ethernet interface, Ethernet headers are used to identify devices via MAC address, and the Address
+Resolution Protocol (ARP) is used to perform that identification.
+
+#### TUN
+A TUN interface does not utilize Ethernet headers, MAC addresses or ARP, in this case relying on RF24Mesh/IP routing instead.
+
+### Limitations
+UDP frames can be up to 512 bytes in length, so UDP/DNS is limited by available memory, and the defined MAX_PAYLOAD_SIZE / UIP_BUFFER_SIZE. If a
+DNS request exceeds the maximum allowed size, it will be dropped. DNS responses for addresses such as 'www.google.com' tend to be much smaller than requests
+for 'google.com', and will generally work with the default configuration.
+
+### MAC address formatting
+RF24Ethernet uses a simple method of formatting the MAC addresses, using the first four bytes to store the characters 'RF24', and the last two bytes to store the
+RF24Network address, which makes identification of nodes via MAC address very simple using standard monitoring tools.
+
+| RF24Network Address| Byte 0 | Byte 1 | Byte 2 | Byte 3 | Byte 4 | Byte 5 |
+|--------------------|--------|--------|--------|--------|--------|--------|
+|      n/a           |   R    |   F    |   2    |   4    |Octal LB|Octal HB|
+|      01            |  0x52  |  0x46  |  0x32  |   0x34 |  0x01  |  0x00  |
+|      011           |  0x52  |  0x46  |  0x32  |   0x34 |  0x09  |  0x00  |
+|      0443          |  0x52  |  0x46  |  0x32  |   0x34 |  0x23  |  0x01  |

--- a/docs/pre_nrf24_changelog.md
+++ b/docs/pre_nrf24_changelog.md
@@ -1,0 +1,55 @@
+# Version Info
+
+## v1.6 - Aug-Dec 2015
+- Address problems with stream functions like client.parseInt() or find()
+- Tested working with MQTT via [PubSub library](https://github.com/knolleary/pubsubclient)
+- Fix: Connection state set before begin allocated
+- Workaround for HTTP servers sending half TCP MSS
+- Automatically assign mesh nodeID based on IP & update examples
+- [ESP8266 (Arduino)](https://github.com/esp8266/Arduino) support
+
+## v1.51RC1 - Apr15-16 2015
+- Seemingly stable release candidate
+- Major change: [RF24Gateway](http://nRF24.github.io/RF24Gateway/) replaces RF24toTUN
+- Now defaults to using RF24Mesh (TUN) interface
+- Apr 16 - Use external buffer for uIP to save memory. Requires Updating RF24Network and RF24Mesh.
+
+## v1.5RC1 - Apr15-16 2015
+- Seemingly stable release candidate
+- Major change: [RF24Gateway](http://nRF24.github.io/RF24Gateway/) replaces RF24toTUN
+- Now defaults to using RF24Mesh (TUN) interface
+- Apr 16 - Use external buffer for uIP to save memory. Requires Updating RF24Network and RF24Mesh.
+
+## v1.4b/1.411b - March 14 - Apr 7 2015
+- Add Ethernet.update() function
+- Improve/Fix outgoing data handling
+- Fix: Hanging in 1.4b
+
+## v1.3b - March 6 2015
+- Major Improvement: Better TCP window handling increases reliability, throughput and performance
+
+## v1.24b - March 3 2015
+- Utilize separate incoming/outgoing buffers (bugfix)
+- Update documentation for DNS & UDP
+- Add waitAvailable() function, update examples to demonstrate usage.
+
+## v1.23b - Jan 22 2015
+- Small bugfixes from v1.20
+- Slightly reduced latency
+- Code clean-up/Reduce code size and memory usage for main Client/Server code
+- Cleaned up some examples, added DNS and SimpleServer_Minimal examples
+
+## v1.221b - Jan 16 2015
+- Add UDP support
+- Add DNS support
+- Add support for up to 512 byte buffer size
+- Reduce used memory and program space
+- Support for multiple connections with per-connection memory  buffers
+
+## v1.1b - Jan 4 2015
+- Add connection timeout to recover from hangs during failed client downloads
+- Better TCP window management to prevent hangs during client downloads
+- Stability improvements
+
+## v1.0b - Dec 2014
+- Outgoing client data corruption should be fixed

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,43 @@
+# Troubleshooting
+
+## Installation & Compilation Errors:
+
+### RPi
+Report issues with the installer at https://github.com/TMRh20/RF24/issues
+
+### Arduino
+Ensure proper library installation.
+- Download and install RF24, RF24Network, RF24Mesh and RF24Ethernet libraries from http://tmrh20.github.io
+- See http://arduino.cc/en/Guide/Libraries ( Note: Library folders may need to be renamed ie: Change RF24Network-Development to RF24Network )
+
+## Test hardware configuration
+
+### RPi
+1. Navigate to the rf24libs/RF24/examples_RPi folder
+2. Configure the correct pins in gettingstarted.cpp (See [general Linux/RPi setup](https://nRF24.github.io/RF24/md_docs_rpi_general.html))
+<!-- http://www.airspayce.com/mikem/bcm2835/group__constants.html#ga63c029bd6500167152db4e57736d0939) -->
+3. Build the examples: `make`
+4. Run an example `sudo ./gettingstarted`
+
+### Arduino
+1. Open the GettingStarted example sketch (File > Examples > RF24 > GettingStarted)
+2. Configure the appropriate CE and CS pins in the example as desired (`RF24 radio(7, 8);`)
+3. Configure the assigned radio number in the example
+4. Upload to Arduino to test
+
+## Testing RF24Gateway and RF24Ethernet
+@note Troubleshooting steps assume a fresh library install with the default configuration, using RF24Mesh/TUN
+@warning The maximum payload size configured in RF24Network_config.h will determine the maximum size of TCP or UDP segments. Set to 1514 (TAP) or 1500 (TUN) on Raspberry Pi/Linux devices for full TCP/IP capabilities. TCP+IP+LL headers add 54 bytes of overhead to each payload with TAP/Ethernet, and 40 bytes with TUN/RF24Mesh
+
+### RPi ([RF24Gateway]http://nRF24.github.io/RF24Gateway/)
+1. Run the included RF24Gateway_ncurses example `sudo ./RF24Gateway_ncurses`
+2. Test connectivity: `ping 10.10.3.<IP_TO_PING-last-octet>`
+3. If connectivity fails, ensure IP information is accurate. Forwarding is required if pinging from a device other than the RPi.
+4. If using pins connections other than the default, edit the RF24 constructor in the example file: ie: `RF24 radio(22, 0);`
+5. Optional: For RPi to RPi communication over RF24, edit the rf24libs/RF24Network/RF24Network_config.h file. Set `#define MAX_PAYLOAD_SIZE 1514`
+
+### Arduino (RF24Ethernet)
+1. Update all RF24 libraries (RF24, RF24Network, RF24Mesh, RF24Ethernet) http://tmrh20.github.io
+2. Open, configure and upload one of the included examples to Arduino. (File > Examples > RF24Ethernet)
+3. Ensure example hardware and pin configuration matches CE and CS pins selected in step 2
+4. If switching between TAP(Ethernet) & TUN(RF24Mesh), ensure the LLHL is defined appropriately in RF24Ethernet/uip-conf.h: `#define UIP_CONF_LLH_LEN 14`

--- a/uip-conf.h
+++ b/uip-conf.h
@@ -55,18 +55,18 @@
  * @{
  */
 
-/** Maximum number of TCP connections. */
+/** @brief Maximum number of TCP connections. */
 #define UIP_CONF_MAX_CONNECTIONS 1
 
-/** Maximum number of listening TCP ports. */
+/** @brief Maximum number of listening TCP ports. */
 #define UIP_CONF_MAX_LISTENPORTS 1
 
 /**
- * uIP buffer size.
+ * @brief uIP buffer size.
  * @note For simplicity, this is automatically set to the MAX_PAYLOAD_SIZE configured in the RF24Network_conf.h file, but can be configured independently
  * of RF24Network if desired.
  *
- * Notes:
+ * @remarks
  * 1. Nodes can use different buffer sizes, direct TCP communication is limited to the smallest
  *  ie: A RPi can be configured to use 1500byte TCP windows, with Arduino nodes using only 120byte TCP windows.
  * 2. Routing nodes handle traffic at the link-layer, so the MAX_PAYLOAD_SIZE is not important, unless they are
@@ -81,7 +81,7 @@
 
 #define UIP_CONF_BUFFER_SIZE MAX_PAYLOAD_SIZE - 2
 /**
- * <b>Optional:</b> Uncomment to disable
+ * @brief <b>Optional:</b> Uncomment to disable
  *
  * Adjust the length of time after which an open connection will be timed out.
  *
@@ -90,7 +90,7 @@
 #define UIP_CONNECTION_TIMEOUT 30000
 
 /**
- * SLIP/TUN - 14 for Ethernet/TAP & 0 for TUN/SLIP
+ * @brief SLIP/TUN - 14 for Ethernet/TAP & 0 for TUN/SLIP
  *
  * Ethernet headers add an additional 14 bytes to each payload.
  *
@@ -99,7 +99,7 @@
 #define UIP_CONF_LLH_LEN 0
 
 /**
- * UDP support on or off (required for DNS)
+ * @brief UDP support on or off (required for DNS)
  * @note DNS support typically requires larger payload sizes (250-300). It seems that DNS servers will typically respond
  * with a single address if requesting an address of www.google.com vs google.com, and this will work with the default payload size
  */
@@ -117,8 +117,8 @@
  */
 
 /**
+ * @brief Adjust the rate at which the IP stack performs periodic processing.
  *
- * Adjust the rate at which the IP stack performs periodic processing.
  * The periodic timer will be called at a rate of 1 second divided by this value
  *
  * Increase this value to reduce response times and increase throughput during user interactions.
@@ -132,13 +132,11 @@
  */
 #define UIP_CONF_ACTIVE_OPEN 1
 
-/**
- * UDP checksums on or off
- */
+/** @brief UDP checksums on or off */
 #define UIP_CONF_UDP_CHECKSUMS   0
 
 /**
- * uIP User Output buffer size
+ * @brief uIP User Output buffer size
  *
  * The output buffer size determines the max
  * length of strings that can be sent by the user, and depends on the uip buffer size
@@ -156,7 +154,7 @@
 #endif
 
 /**
- * <b>Optional:</b> Used with UIP_CONNECTION_TIMEOUT
+ * @brief <b>Optional:</b> Used with UIP_CONNECTION_TIMEOUT
  *
  * If an open connection is not receiving data, the connection will be restarted.
  *
@@ -173,11 +171,11 @@
 /******************** END USER CONFIG ***********************************/
 
 /********** TMRh20: This option is not yet valid **********/
-/* for TCP */
+/* @brief for TCP */
 #define UIP_SOCKET_NUMPACKETS    1
 
 /**
- * The TCP receive window.
+ * @brief The TCP receive window.
  *
  * This is should not be to set to more than
  * UIP_BUFSIZE - UIP_LLH_LEN - UIP_TCPIP_HLEN.
@@ -194,14 +192,14 @@
 #define UIP_CONF_TCP_MSS OUTPUT_BUFFER_SIZE
 
 /**
- * CPU byte order.
+ * @brief CPU byte order.
  *
  * \hideinitializer
  */
 #define UIP_CONF_BYTE_ORDER      LITTLE_ENDIAN
 
 /**
- * Logging on or off
+ * @brief Logging on or off
  *
  * \hideinitializer
  */
@@ -209,7 +207,7 @@
 #define UIP_CONF_LOGGING         0
 
 /**
- * uIP statistics on or off
+ * @brief uIP statistics on or off
  *
  * \hideinitializer
  */
@@ -230,7 +228,7 @@
 
 
 /**
- * 8 bit datatype
+ * @brief 8 bit datatype
  *
  * This typedef defines the 8-bit type used throughout uIP.
  *
@@ -239,7 +237,7 @@
 typedef uint8_t u8_t;
 
 /**
- * 16 bit datatype
+ * @brief 16 bit datatype
  *
  * This typedef defines the 16-bit type used throughout uIP.
  *
@@ -248,7 +246,7 @@ typedef uint8_t u8_t;
 typedef uint16_t u16_t;
 
 /**
- * Statistics datatype
+ * @brief Statistics datatype
  *
  * This typedef defines the dataype used for keeping statistics in
  * uIP.

--- a/uip-conf.h
+++ b/uip-conf.h
@@ -150,9 +150,9 @@
 #define UIP_CONF_EXTERNAL_BUFFER
 
 #if UIP_CONF_BUFFER_SIZE >= 512
-  #define OUTPUT_BUFFER_SIZE 511
+    #define OUTPUT_BUFFER_SIZE 511
 #else
-  #define OUTPUT_BUFFER_SIZE UIP_CONF_BUFFER_SIZE - UIP_CONF_LLH_LEN - UIP_TCPIP_HLEN
+    #define OUTPUT_BUFFER_SIZE UIP_CONF_BUFFER_SIZE - UIP_CONF_LLH_LEN - UIP_TCPIP_HLEN
 #endif
 
 /**
@@ -184,12 +184,11 @@
  * @note Must be an odd number or the TCP/IP sequence gets out of order with payloads larger than 511 bytes
  * I think this might be a bug or missing feature of the uip stack
  */
-
 #if UIP_CONF_BUFFER_SIZE >= 512
-  #define UIP_CONF_RECEIVE_WINDOW 511
+    #define UIP_CONF_RECEIVE_WINDOW 511
 #else
-//#define UIP_CONF_RECEIVE_WINDOW UIP_CONF_BUFFER_SIZE *2 - UIP_CONF_LLH_LEN - UIP_TCPIP_HLEN //This is set automatically to the max allowable size
-#define UIP_CONF_RECEIVE_WINDOW UIP_CONF_BUFFER_SIZE - UIP_CONF_LLH_LEN - UIP_TCPIP_HLEN //This is set automatically to the max allowable size
+    //#define UIP_CONF_RECEIVE_WINDOW UIP_CONF_BUFFER_SIZE *2 - UIP_CONF_LLH_LEN - UIP_TCPIP_HLEN //This is set automatically to the max allowable size
+    #define UIP_CONF_RECEIVE_WINDOW UIP_CONF_BUFFER_SIZE - UIP_CONF_LLH_LEN - UIP_TCPIP_HLEN //This is set automatically to the max allowable size
 #endif
 
 #define UIP_CONF_TCP_MSS OUTPUT_BUFFER_SIZE
@@ -218,15 +217,15 @@
 
 // Define config for TAP or TUN based on Link-layer header length
 #if UIP_CONF_LLH_LEN > 0
-  #define RF24_TAP
+    #define RF24_TAP
 #endif
 
 #if defined UIP_TIMER_DIVISOR
-  #if UIP_TIMER_DIVISOR > 5
-    #define UIP_CONF_RTO (UIP_TIMER_DIVISOR/2)
-  #else
-    #define UIP_CONF_RTO 3
-  #endif
+    #if UIP_TIMER_DIVISOR > 5
+        #define UIP_CONF_RTO (UIP_TIMER_DIVISOR/2)
+    #else
+        #define UIP_CONF_RTO 3
+    #endif
 #endif
 
 
@@ -280,5 +279,3 @@ void uip_log(char* msg);
 #endif
 
 #endif /* __UIP_CONF_H__ */
-
-


### PR DESCRIPTION
 This is part of my crusade to
- abstract docs (main page and all "Related Pages" now live in the docs folder)
- fix formatting (mostly was just inconsistent indentation & missing docs interlinking between class defs and config defs)
- added a CONTRIBUTING.md file

NOTE: This lib is unlicensed.

I also noticed the troubleshooting page directed users to the BCM27xx docs about choosing pin numbers to the RF24 c'tor; this has been changed to direct readers to the RF24 docs' _md_docs_rpi_general.html_ docs (as generated by doxygen).
