### PR TITLE
Fix for connection issues

### DIFF
--- a/RF24Client.cpp
+++ b/RF24Client.cpp
@@ -240,6 +240,13 @@ void serialip_appcall(void)
 {
     uip_userdata_t *u = (uip_userdata_t *)uip_conn->appstate;
 
+    if(u && u->connectTimeout > 0){
+      if(millis() - u->connectTimer > u->connectTimeout && u->initialData == false){
+        uip_close();
+        IF_RF24ETHERNET_DEBUG_CLIENT(Serial.println(); Serial.print(millis()); Serial.println("UIP Client close(timeout)"););
+      }
+    }
+        
     /*******Connected**********/
     if (!u && uip_connected())
     {
@@ -265,6 +272,8 @@ void serialip_appcall(void)
         {
             IF_RF24ETHERNET_DEBUG_CLIENT(Serial.println(); Serial.print(millis()); Serial.print(F(" UIPClient uip_newdata, uip_len:")); Serial.println(uip_len););
 
+            u->initialData = true;
+                        
             if (u->sent)
             {
                 u->hold = (u->out_pos = (u->windowOpened = (u->packets_out = false)));
@@ -428,6 +437,8 @@ uip_userdata_t *RF24Client::_allocateData()
             data->dataPos = 0;
             data->out_pos = 0;
             data->hold = 0;
+            data->initialData = false;
+            data->connectTimer = millis();
             return data;
         }
     }

--- a/RF24Client.h
+++ b/RF24Client.h
@@ -66,6 +66,9 @@ typedef struct {
     uint32_t restartTime;
     uint32_t restartInterval;
     uint32_t connAbortTime;
+    uint32_t connectTimeout;
+    uint32_t connectTimer;
+    bool initialData;
     uint8_t myData[OUTPUT_BUFFER_SIZE];
 } uip_userdata_t;
 

--- a/RF24Client.h
+++ b/RF24Client.h
@@ -68,8 +68,8 @@ typedef struct {
     uint32_t connAbortTime;
     uint32_t connectTimeout;
     uint32_t connectTimer;
-    bool initialData;
     uint8_t myData[OUTPUT_BUFFER_SIZE];
+    bool initialData;
 } uip_userdata_t;
 
 

--- a/RF24Server.cpp
+++ b/RF24Server.cpp
@@ -82,3 +82,13 @@ size_t RF24Server::write(const uint8_t *buf, size_t size)
     }
     return ret;
 }
+
+void RF24Server::setTimeout(uint32_t timeout)
+{
+    for(uint8_t i = 0; i < UIP_CONNS; i++){
+        uip_userdata_t *data = &RF24Client::all_data[i];
+        if(data){
+            data->connectTimeout = timeout;
+        }
+    }
+}

--- a/RF24Server.h
+++ b/RF24Server.h
@@ -35,6 +35,7 @@ public:
     size_t write(uint8_t);
     size_t write(const uint8_t *buf, size_t size);
     using Print::write;
+    void setTimeout(uint32_t timeout);
 
 private:
     uint16_t _port;

--- a/examples/Getting_Started_SimpleServer_Mesh/Getting_Started_SimpleServer_Mesh.ino
+++ b/examples/Getting_Started_SimpleServer_Mesh/Getting_Started_SimpleServer_Mesh.ino
@@ -119,6 +119,10 @@ void setup() {
   // Listen for incoming connections on TCP port 1000.  Each incoming
   // connection will result in the uip_callback() function being called.
   server.begin();
+
+  // If no data is received from an incoming connection in the first 30 seconds,
+  // close the connection
+  server.setTimeout(30000);
 }
 
 uint32_t mesh_timer = 0;

--- a/examples/InteractiveServer_Mesh/InteractiveServer_Mesh.ino
+++ b/examples/InteractiveServer_Mesh/InteractiveServer_Mesh.ino
@@ -62,6 +62,7 @@ void setup() {
   Ethernet.set_gateway(gwIP);
 
   server.begin();
+  server.setTimeout(30000);
 
 }
 

--- a/examples/InteractiveServer_Mesh_ESPWifi/InteractiveServer_Mesh_ESPWifi.ino
+++ b/examples/InteractiveServer_Mesh_ESPWifi/InteractiveServer_Mesh_ESPWifi.ino
@@ -60,6 +60,7 @@ void setup() {
   Ethernet.set_gateway(gwIP);
 
   server.begin();
+  server.setTimeout(30000);
   // prepare GPIO2
   pinMode(LED_PIN, OUTPUT);
   digitalWrite(LED_PIN, 0);


### PR DESCRIPTION
It seems there is a gap in the processes between UIP and RF24Ethernet core because, when using the server side of RF24Ethernet, the UIP stack doesn't kick things over to RF24Ethernet to handle incoming connections until data is sent. If a user connects to an RF24Ethernet server running the HTTP example, they can create a DOS condition by not sending any packets, tying up the only available connection indefinitely. As long as data is sent, the server example will handle it and close the connection. This fixes the issue by closing connections if initial data is not sent within a defined timeout period, default 0 seconds to disable this functionality.

If this works, we can merge this after a couple/few weeks.

Closes #30 
