### PR TITLE
Simplify timeouts and enable for both servers and clients by default

### DIFF
--- a/Dns.cpp
+++ b/Dns.cpp
@@ -6,41 +6,41 @@
 
 #if UIP_CONF_UDP > 0
 
-#define SOCKET_NONE	255
-// Various flags and header field values for a DNS message
-#define UDP_HEADER_SIZE	8
-#define DNS_HEADER_SIZE	12
-#define TTL_SIZE        4
-#define QUERY_FLAG               (0)
-#define RESPONSE_FLAG            (1<<15)
-#define QUERY_RESPONSE_MASK      (1<<15)
-#define OPCODE_STANDARD_QUERY    (0)
-#define OPCODE_INVERSE_QUERY     (1<<11)
-#define OPCODE_STATUS_REQUEST    (2<<11)
-#define OPCODE_MASK              (15<<11)
-#define AUTHORITATIVE_FLAG       (1<<10)
-#define TRUNCATION_FLAG          (1<<9)
-#define RECURSION_DESIRED_FLAG   (1<<8)
-#define RECURSION_AVAILABLE_FLAG (1<<7)
-#define RESP_NO_ERROR            (0)
-#define RESP_FORMAT_ERROR        (1)
-#define RESP_SERVER_FAILURE      (2)
-#define RESP_NAME_ERROR          (3)
-#define RESP_NOT_IMPLEMENTED     (4)
-#define RESP_REFUSED             (5)
-#define RESP_MASK                (15)
-#define TYPE_A                   (0x0001)
-#define CLASS_IN                 (0x0001)
-#define LABEL_COMPRESSION_MASK   (0xC0)
-// Port number that DNS servers listen on
-#define DNS_PORT        53
+    #define SOCKET_NONE 255
+    // Various flags and header field values for a DNS message
+    #define UDP_HEADER_SIZE          8
+    #define DNS_HEADER_SIZE          12
+    #define TTL_SIZE                 4
+    #define QUERY_FLAG               (0)
+    #define RESPONSE_FLAG            (1 << 15)
+    #define QUERY_RESPONSE_MASK      (1 << 15)
+    #define OPCODE_STANDARD_QUERY    (0)
+    #define OPCODE_INVERSE_QUERY     (1 << 11)
+    #define OPCODE_STATUS_REQUEST    (2 << 11)
+    #define OPCODE_MASK              (15 << 11)
+    #define AUTHORITATIVE_FLAG       (1 << 10)
+    #define TRUNCATION_FLAG          (1 << 9)
+    #define RECURSION_DESIRED_FLAG   (1 << 8)
+    #define RECURSION_AVAILABLE_FLAG (1 << 7)
+    #define RESP_NO_ERROR            (0)
+    #define RESP_FORMAT_ERROR        (1)
+    #define RESP_SERVER_FAILURE      (2)
+    #define RESP_NAME_ERROR          (3)
+    #define RESP_NOT_IMPLEMENTED     (4)
+    #define RESP_REFUSED             (5)
+    #define RESP_MASK                (15)
+    #define TYPE_A                   (0x0001)
+    #define CLASS_IN                 (0x0001)
+    #define LABEL_COMPRESSION_MASK   (0xC0)
+    // Port number that DNS servers listen on
+    #define DNS_PORT 53
 
-// Possible return codes from ProcessResponse
-#define SUCCESS          1
-#define TIMED_OUT        -1
-#define INVALID_SERVER   -2
-#define TRUNCATED        -3
-#define INVALID_RESPONSE -4
+    // Possible return codes from ProcessResponse
+    #define SUCCESS          1
+    #define TIMED_OUT        -1
+    #define INVALID_SERVER   -2
+    #define TRUNCATED        -3
+    #define INVALID_RESPONSE -4
 
 void DNSClient::begin(const IPAddress& aDNSServer)
 {
@@ -48,13 +48,11 @@ void DNSClient::begin(const IPAddress& aDNSServer)
     iRequestId = 0;
 }
 
-
 int DNSClient::inet_aton(const char* aIPAddrString, IPAddress& aResult)
 {
     // See if we've been given a valid IP address
-    const char* p =aIPAddrString;
-    while (*p &&
-           ( (*p == '.') || (*p >= '0') || (*p <= '9') ))
+    const char* p = aIPAddrString;
+    while (*p && ((*p == '.') || (*p >= '0') || (*p <= '9')))
     {
         p++;
     }
@@ -63,8 +61,8 @@ int DNSClient::inet_aton(const char* aIPAddrString, IPAddress& aResult)
     {
         // It's looking promising, we haven't found any invalid characters
         p = aIPAddrString;
-        int segment =0;
-        int segmentValue =0;
+        int segment = 0;
+        int segmentValue = 0;
         while (*p && (segment < 4))
         {
             if (*p == '.')
@@ -85,7 +83,7 @@ int DNSClient::inet_aton(const char* aIPAddrString, IPAddress& aResult)
             else
             {
                 // Next digit
-                segmentValue = (segmentValue*10)+(*p - '0');
+                segmentValue = (segmentValue * 10) + (*p - '0');
             }
             p++;
         }
@@ -111,7 +109,7 @@ int DNSClient::inet_aton(const char* aIPAddrString, IPAddress& aResult)
 
 int DNSClient::getHostByName(const char* aHostname, IPAddress& aResult)
 {
-    int ret =0;
+    int ret = 0;
 
     // See if it's a numeric IP address
     if (inet_aton(aHostname, aResult))
@@ -123,12 +121,12 @@ int DNSClient::getHostByName(const char* aHostname, IPAddress& aResult)
     // Check we've got a valid DNS server to use
     if (iDNSServer == INADDR_NONE)
     {
-	    IF_RF24ETHERNET_DEBUG_DNS( Serial.println(F("RF24DNS Invalid DNS Server")) );
+        IF_RF24ETHERNET_DEBUG_DNS(Serial.println(F("RF24DNS Invalid DNS Server")));
         return INVALID_SERVER;
     }
 
     // Find a socket to use
-    if (iUdp.begin(1024+(millis() & 0xF)) == 1)
+    if (iUdp.begin(1024 + (millis() & 0xF)) == 1)
     {
         // Try up to three times
         int retries = 0;
@@ -197,10 +195,10 @@ uint16_t DNSClient::BuildRequest(const char* aName)
     twoByteBuffer = htons(QUERY_FLAG | OPCODE_STANDARD_QUERY | RECURSION_DESIRED_FLAG);
     iUdp.write((uint8_t*)&twoByteBuffer, sizeof(twoByteBuffer));
 
-    twoByteBuffer = htons(1);  // One question record
+    twoByteBuffer = htons(1); // One question record
     iUdp.write((uint8_t*)&twoByteBuffer, sizeof(twoByteBuffer));
 
-    twoByteBuffer = 0;  // Zero answer records
+    twoByteBuffer = 0; // Zero answer records
     iUdp.write((uint8_t*)&twoByteBuffer, sizeof(twoByteBuffer));
 
     iUdp.write((uint8_t*)&twoByteBuffer, sizeof(twoByteBuffer));
@@ -208,28 +206,28 @@ uint16_t DNSClient::BuildRequest(const char* aName)
     iUdp.write((uint8_t*)&twoByteBuffer, sizeof(twoByteBuffer));
 
     // Build question
-    const char* start =aName;
-    const char* end =start;
+    const char* start = aName;
+    const char* end = start;
     uint8_t len;
     // Run through the name being requested
     while (*end)
     {
         // Find out how long this section of the name is
         end = start;
-        while (*end && (*end != '.') )
+        while (*end && (*end != '.'))
         {
             end++;
         }
 
-        if (end-start > 0)
+        if (end - start > 0)
         {
             // Write out the size of this section
-            len = end-start;
+            len = end - start;
             iUdp.write(&len, sizeof(len));
             // And then write out the section
-            iUdp.write((uint8_t*)start, end-start);
+            iUdp.write((uint8_t*)start, end - start);
         }
-        start = end+1;
+        start = end + 1;
     }
 
     // We've got to the end of the question name, so
@@ -240,83 +238,80 @@ uint16_t DNSClient::BuildRequest(const char* aName)
     twoByteBuffer = htons(TYPE_A);
     iUdp.write((uint8_t*)&twoByteBuffer, sizeof(twoByteBuffer));
 
-    twoByteBuffer = htons(CLASS_IN);  // Internet class of question
+    twoByteBuffer = htons(CLASS_IN); // Internet class of question
     iUdp.write((uint8_t*)&twoByteBuffer, sizeof(twoByteBuffer));
     // Success!  Everything buffered okay
     return 1;
 }
-
 
 uint16_t DNSClient::ProcessResponse(uint16_t aTimeout, IPAddress& aAddress)
 {
     uint32_t startTime = millis();
 
     // Wait for a response packet
-    while(iUdp.parsePacket() <= 0)
+    while (iUdp.parsePacket() <= 0)
     {
-        if((millis() - startTime) > aTimeout){
-            IF_RF24ETHERNET_DEBUG_DNS( Serial.println(F("RF24 DNS - Request timed out")); );
-			return TIMED_OUT;
-		}
-        //delay(50);
+        if ((millis() - startTime) > aTimeout) {
+            IF_RF24ETHERNET_DEBUG_DNS(Serial.println(F("RF24 DNS - Request timed out")););
+            return TIMED_OUT;
+        }
+        // delay(50);
     }
 
     // We've had a reply!
     // Read the UDP header
     uint8_t header[DNS_HEADER_SIZE]; // Enough space to reuse for the DNS header
     // Check that it's a response from the right server and the right port
-    if ( (iDNSServer != iUdp.remoteIP()) ||
-        (iUdp.remotePort() != DNS_PORT) )
+    if ((iDNSServer != iUdp.remoteIP()) || (iUdp.remotePort() != DNS_PORT))
     {
         // It's not from who we expected
-		IF_RF24ETHERNET_DEBUG_DNS( Serial.println(F("RF24DNS - Invalid Server: ")); );
+        IF_RF24ETHERNET_DEBUG_DNS(Serial.println(F("RF24DNS - Invalid Server: ")););
         return INVALID_SERVER;
     }
 
     // Read through the rest of the response
     if (iUdp.available() < DNS_HEADER_SIZE)
     {
-		IF_RF24ETHERNET_DEBUG_DNS( Serial.println(F("RF24DNS - Truncated")); );
+        IF_RF24ETHERNET_DEBUG_DNS(Serial.println(F("RF24DNS - Truncated")););
         return TRUNCATED;
     }
-	IF_RF24ETHERNET_DEBUG_DNS( Serial.print(F("RF24DNS - DNS Header Size: ")); Serial.println(DNS_HEADER_SIZE); );
+    IF_RF24ETHERNET_DEBUG_DNS(Serial.print(F("RF24DNS - DNS Header Size: ")); Serial.println(DNS_HEADER_SIZE););
     iUdp.read(header, DNS_HEADER_SIZE);
 
     uint16_t header_flags = htons(*((uint16_t*)&header[2]));
     // Check that it's a response to this request
-    if ( ( iRequestId != (*((uint16_t*)&header[0])) ) ||
-        ((header_flags & QUERY_RESPONSE_MASK) != (uint16_t)RESPONSE_FLAG) )
+    if ((iRequestId != (*((uint16_t*)&header[0]))) || ((header_flags & QUERY_RESPONSE_MASK) != (uint16_t)RESPONSE_FLAG))
     {
         // Mark the entire packet as read
         iUdp.flush();
-		IF_RF24ETHERNET_DEBUG_DNS( Serial.println(F("RF24DNS - Invalid Response 1, Flushing")); );
+        IF_RF24ETHERNET_DEBUG_DNS(Serial.println(F("RF24DNS - Invalid Response 1, Flushing")););
         return INVALID_RESPONSE;
     }
     // Check for any errors in the response (or in our request)
     // although we don't do anything to get round these
-    if ( (header_flags & TRUNCATION_FLAG) || (header_flags & RESP_MASK) )
+    if ((header_flags & TRUNCATION_FLAG) || (header_flags & RESP_MASK))
     {
         // Mark the entire packet as read
-		IF_RF24ETHERNET_DEBUG_DNS( Serial.println(F("RF24DNS - Invalid Response 2, Flushing")); );
+        IF_RF24ETHERNET_DEBUG_DNS(Serial.println(F("RF24DNS - Invalid Response 2, Flushing")););
         iUdp.flush();
-        return -5; //INVALID_RESPONSE;
+        return -5; // INVALID_RESPONSE;
     }
 
     // And make sure we've got (at least) one answer
     uint16_t answerCount = htons(*((uint16_t*)&header[6]));
-    if (answerCount == 0 )
+    if (answerCount == 0)
     {
         // Mark the entire packet as read
-		IF_RF24ETHERNET_DEBUG_DNS( Serial.println(F("RF24DNS - No Answer, Flushing")); );
+        IF_RF24ETHERNET_DEBUG_DNS(Serial.println(F("RF24DNS - No Answer, Flushing")););
         iUdp.flush();
-        return -6; //INVALID_RESPONSE;
+        return -6; // INVALID_RESPONSE;
     }
 
-	IF_RF24ETHERNET_DEBUG_DNS( Serial.print(F("RF24DNS OK, skipping questions ")); Serial.println(header[5]); );
+    IF_RF24ETHERNET_DEBUG_DNS(Serial.print(F("RF24DNS OK, skipping questions ")); Serial.println(header[5]););
 
     // Skip over any questions
-    for (uint16_t i =0; i < HTONS(*((uint16_t*)&header[4])); i++)
-//	for (uint16_t i =0; i < wtf; i++)
+    for (uint16_t i = 0; i < HTONS(*((uint16_t*)&header[4])); i++)
+    //	for (uint16_t i =0; i < wtf; i++)
     {
         // Skip over the name
         uint8_t len;
@@ -327,8 +322,8 @@ uint16_t DNSClient::ProcessResponse(uint16_t aTimeout, IPAddress& aAddress)
             {
                 // Don't need to actually read the data out for the string, just
                 // advance ptr to beyond it
-				IF_RF24ETHERNET_DEBUG_DNS( Serial.print(F("RF24DNS Reading ")); Serial.println(len); );
-                while(len--)
+                IF_RF24ETHERNET_DEBUG_DNS(Serial.print(F("RF24DNS Reading ")); Serial.println(len););
+                while (len--)
                 {
                     iUdp.read(); // we don't care about the returned byte
                 }
@@ -336,7 +331,7 @@ uint16_t DNSClient::ProcessResponse(uint16_t aTimeout, IPAddress& aAddress)
         } while (len != 0);
 
         // Now jump over the type and class
-        for (int i =0; i < 4; i++)
+        for (int i = 0; i < 4; i++)
         {
             iUdp.read(); // we don't care about the returned byte
         }
@@ -346,8 +341,8 @@ uint16_t DNSClient::ProcessResponse(uint16_t aTimeout, IPAddress& aAddress)
     // There might be more than one answer (although we'll just use the first
     // type A answer) and some authority and additional resource records but
     // we're going to ignore all of them.
-    IF_RF24ETHERNET_DEBUG_DNS( Serial.print(F("RF24DNS Answer Count: "));  Serial.println(answerCount); );
-    for (uint16_t i =0; i < answerCount; i++)
+    IF_RF24ETHERNET_DEBUG_DNS(Serial.print(F("RF24DNS Answer Count: ")); Serial.println(answerCount););
+    for (uint16_t i = 0; i < answerCount; i++)
     {
         // Skip the name
         uint8_t len;
@@ -362,7 +357,7 @@ uint16_t DNSClient::ProcessResponse(uint16_t aTimeout, IPAddress& aAddress)
                     // And it's got a length
                     // Don't need to actually read the data out for the string,
                     // just advance ptr to beyond it
-                    while(len--)
+                    while (len--)
                     {
                         iUdp.read(); // we don't care about the returned byte
                     }
@@ -389,9 +384,9 @@ uint16_t DNSClient::ProcessResponse(uint16_t aTimeout, IPAddress& aAddress)
         iUdp.read((uint8_t*)&answerType, sizeof(answerType));
         iUdp.read((uint8_t*)&answerClass, sizeof(answerClass));
 
-		IF_RF24ETHERNET_DEBUG_DNS( Serial.print(F("RF24DNS Type: ")); Serial.println(HTONS(answerType),HEX);   Serial.print(F("RF24DNS Class: ")); Serial.println(HTONS(answerClass),HEX);  );
+        IF_RF24ETHERNET_DEBUG_DNS(Serial.print(F("RF24DNS Type: ")); Serial.println(HTONS(answerType), HEX); Serial.print(F("RF24DNS Class: ")); Serial.println(HTONS(answerClass), HEX););
         // Ignore the Time-To-Live as we don't do any caching
-        for (int i =0; i < TTL_SIZE; i++)
+        for (int i = 0; i < TTL_SIZE; i++)
         {
             iUdp.read(); // we don't care about the returned byte
         }
@@ -400,16 +395,16 @@ uint16_t DNSClient::ProcessResponse(uint16_t aTimeout, IPAddress& aAddress)
         // Don't need header_flags anymore, so we can reuse it here
         iUdp.read((uint8_t*)&header_flags, sizeof(header_flags));
 
-        if ( (HTONS(answerType) == TYPE_A) && (HTONS(answerClass) == CLASS_IN) )
-		//if ( (answerType == TYPE_A) && (answerClass == CLASS_IN) )
+        if ((HTONS(answerType) == TYPE_A) && (HTONS(answerClass) == CLASS_IN))
+        // if ( (answerType == TYPE_A) && (answerClass == CLASS_IN) )
         {
             if (HTONS(header_flags) != 4)
             {
                 // It's a weird size
                 // Mark the entire packet as read
-				IF_RF24ETHERNET_DEBUG_DNS( Serial.println(F("RF24DNS Flush invalid")); );
+                IF_RF24ETHERNET_DEBUG_DNS(Serial.println(F("RF24DNS Flush invalid")););
                 iUdp.flush();
-                return -9;//INVALID_RESPONSE;
+                return -9; // INVALID_RESPONSE;
             }
             iUdp.read(aAddress.raw_address(), 4);
             return SUCCESS;
@@ -417,9 +412,9 @@ uint16_t DNSClient::ProcessResponse(uint16_t aTimeout, IPAddress& aAddress)
         else
         {
             // This isn't an answer type we're after, move onto the next one
-			IF_RF24ETHERNET_DEBUG_DNS( Serial.print(F("RF24DNS - Get next answer type")); Serial.println(header_flags,HEX); );
-            for (uint16_t i =0; i < HTONS(header_flags); i++)
-			//for (uint16_t i =0; i < header_flags; i++)
+            IF_RF24ETHERNET_DEBUG_DNS(Serial.print(F("RF24DNS - Get next answer type")); Serial.println(header_flags, HEX););
+            for (uint16_t i = 0; i < HTONS(header_flags); i++)
+            // for (uint16_t i =0; i < header_flags; i++)
             {
                 iUdp.read(); // we don't care about the returned byte
             }
@@ -430,7 +425,7 @@ uint16_t DNSClient::ProcessResponse(uint16_t aTimeout, IPAddress& aAddress)
     iUdp.flush();
 
     // If we get here then we haven't found an answer
-    return -10;//INVALID_RESPONSE;
+    return -10; // INVALID_RESPONSE;
 }
 
 #endif

--- a/Dns.h
+++ b/Dns.h
@@ -12,7 +12,6 @@
 class DNSClient
 {
 public:
-
     void begin(const IPAddress& aDNSServer);
 
     /**
@@ -22,7 +21,7 @@ public:
      * @result 1 if aIPAddrString was successfully converted to an IP address,
      * else error code
      */
-    int inet_aton(const char *aIPAddrString, IPAddress& aResult);
+    int inet_aton(const char* aIPAddrString, IPAddress& aResult);
 
     /**
      * Resolve the given hostname to an IP address.

--- a/RF24Client.cpp
+++ b/RF24Client.cpp
@@ -243,15 +243,14 @@ void serialip_appcall(void)
 
 #if UIP_CONNECTION_TIMEOUT > 0
     if (u && u->connectTimeout > 0) {
+        if(!u->initialData){
+            u->connectTimer = millis();
+            u->initialData = true;
+        }else
         if (millis() - u->connectTimer > u->connectTimeout){
             u->state |= UIP_CLIENT_CLOSE;
             u->connectTimer = millis();
             IF_RF24ETHERNET_DEBUG_CLIENT(Serial.println(); Serial.print(millis()); Serial.println("UIP Client close(timeout)"););
-        }else{
-          if(!u->initialData){
-            u->connectTimer = millis();
-            u->initialData = true;
-          }
         }
     }
 #endif

--- a/RF24Client.cpp
+++ b/RF24Client.cpp
@@ -41,7 +41,7 @@ int RF24Client::connect(IPAddress ip, uint16_t port)
 {
 #if UIP_ACTIVE_OPEN > 0
 
-    //do{
+    // do{
 
     stop();
     uip_ipaddr_t ipaddr;
@@ -75,10 +75,10 @@ int RF24Client::connect(IPAddress ip, uint16_t port)
     #endif
         }
     }
-    //delay(25);
-    //}while(millis()-timer < 175);
+    // delay(25);
+    // }while(millis()-timer < 175);
 
-#endif //Active open enabled
+#endif // Active open enabled
 
     return 0;
 }
@@ -105,7 +105,7 @@ int RF24Client::connect(const char* host, uint16_t port)
         return connect(remote_addr, port);
     }
 #else  // ! UIP_UDP
-    //Do something with the input parameters to prevent compile time warnings
+    // Do something with the input parameters to prevent compile time warnings
     if (host) {
     };
     if (port) {
@@ -214,7 +214,7 @@ test2:
             size_t remain = size - total_written;
             payloadSize = rf24_min(remain, UIP_TCP_MSS);
 
-            //RF24EthernetClass::tick();
+            // RF24EthernetClass::tick();
             goto test2;
         }
         return u->out_pos;
@@ -227,9 +227,9 @@ test2:
 
 void uip_log(char* msg)
 {
-    //Serial.println();
-    //Serial.println("** UIP LOG **");
-    //Serial.println(msg);
+    // Serial.println();
+    // Serial.println("** UIP LOG **");
+    // Serial.println(msg);
     if (msg)
     {
     };
@@ -243,11 +243,11 @@ void serialip_appcall(void)
 
 #if UIP_CONNECTION_TIMEOUT > 0
     if (u && u->connectTimeout > 0) {
-        if(!u->initialData){
+        if (!u->initialData) {
             u->connectTimer = millis();
             u->initialData = true;
-        }else
-        if (millis() - u->connectTimer > u->connectTimeout){
+        }
+        else if (millis() - u->connectTimer > u->connectTimeout) {
             u->state |= UIP_CLIENT_CLOSE;
             u->connectTimer = millis();
             IF_RF24ETHERNET_DEBUG_CLIENT(Serial.println(); Serial.print(millis()); Serial.println("UIP Client close(timeout)"););
@@ -264,9 +264,9 @@ void serialip_appcall(void)
 
         if (u)
         {
-            #if UIP_CONNECTION_TIMEOUT > 0
-              u->connectTimer = millis();
-            #endif
+#if UIP_CONNECTION_TIMEOUT > 0
+            u->connectTimer = millis();
+#endif
             uip_conn->appstate = u;
             IF_RF24ETHERNET_DEBUG_CLIENT(Serial.print(F("UIPClient allocated state: ")); Serial.println(u->state, BIN););
         }
@@ -282,9 +282,9 @@ void serialip_appcall(void)
         if (uip_newdata())
         {
             IF_RF24ETHERNET_DEBUG_CLIENT(Serial.println(); Serial.print(millis()); Serial.print(F(" UIPClient uip_newdata, uip_len:")); Serial.println(uip_len););
-            #if UIP_CONNECTION_TIMEOUT > 0
-              u->connectTimer = millis();
-            #endif
+#if UIP_CONNECTION_TIMEOUT > 0
+            u->connectTimer = millis();
+#endif
 
             if (u->sent)
             {
@@ -336,15 +336,15 @@ void serialip_appcall(void)
             u->state &= ~UIP_CLIENT_RESTART;
             u->hold = (u->out_pos = (u->windowOpened = (u->packets_out = false)));
             u->restartTime = millis();
-            #if UIP_CONNECTION_TIMEOUT > 0
+#if UIP_CONNECTION_TIMEOUT > 0
             u->connectTimer = millis();
-            #endif
+#endif
         }
 
         /*******Polling**********/
         if (uip_poll() || uip_rexmit())
         {
-            //IF_RF24ETHERNET_DEBUG_CLIENT( Serial.println(); Serial.println(F("UIPClient uip_poll")); );
+            // IF_RF24ETHERNET_DEBUG_CLIENT( Serial.println(); Serial.println(F("UIPClient uip_poll")); );
 
             if (u->packets_out != 0)
             {
@@ -359,24 +359,24 @@ void serialip_appcall(void)
                 // Only call this if the TCP window has already been re-opened, the connection is being polled, but no data
                 // has been acked
                 if (!(u->state & (UIP_CLIENT_CLOSE | UIP_CLIENT_REMOTECLOSED)))
-            {
-
-                if (u->windowOpened == true && u->state & UIP_CLIENT_RESTART && millis() - u->restartTime > u->restartInterval)
                 {
-                    u->restartTime = millis();
+
+                    if (u->windowOpened == true && u->state & UIP_CLIENT_RESTART && millis() - u->restartTime > u->restartInterval)
+                    {
+                        u->restartTime = millis();
 #if defined RF24ETHERNET_DEBUG_CLIENT || defined ETH_DEBUG_L1
                         Serial.println();
                         Serial.print(millis());
-                        #if UIP_CONNECTION_TIMEOUT > 0
-                          Serial.print(F(" UIPClient Re-Open TCP Window, time remaining before abort: "));
-                          Serial.println(  UIP_CONNECTION_TIMEOUT - (millis() - u->connectTimer));
-                        #endif
+    #if UIP_CONNECTION_TIMEOUT > 0
+                        Serial.print(F(" UIPClient Re-Open TCP Window, time remaining before abort: "));
+                        Serial.println(UIP_CONNECTION_TIMEOUT - (millis() - u->connectTimer));
+    #endif
 #endif
-                    u->restartInterval += 500;
-                    u->restartInterval = rf24_min(u->restartInterval, 7000);
-                    uip_restart();
+                        u->restartInterval += 500;
+                        u->restartInterval = rf24_min(u->restartInterval, 7000);
+                        uip_restart();
+                    }
                 }
-            }
         }
 
         /*******Close**********/
@@ -434,10 +434,10 @@ uip_userdata_t* RF24Client::_allocateData()
             data->out_pos = 0;
             data->hold = 0;
             data->initialData = false;
-            #if (UIP_CONNECTION_TIMEOUT > 0)
-              data->connectTimer = millis();
-              data->connectTimeout = UIP_CONNECTION_TIMEOUT;
-            #endif
+#if (UIP_CONNECTION_TIMEOUT > 0)
+            data->connectTimer = millis();
+            data->connectTimeout = UIP_CONNECTION_TIMEOUT;
+#endif
             return data;
         }
     }

--- a/RF24Client.cpp
+++ b/RF24Client.cpp
@@ -241,12 +241,20 @@ void serialip_appcall(void)
 {
     uip_userdata_t* u = (uip_userdata_t*)uip_conn->appstate;
 
+#if UIP_CONNECTION_TIMEOUT > 0
     if (u && u->connectTimeout > 0) {
-        if (millis() - u->connectTimer > u->connectTimeout && u->initialData == false) {
-            uip_close();
+        if (millis() - u->connectTimer > u->connectTimeout){
+            u->state |= UIP_CLIENT_CLOSE;
+            u->connectTimer = millis();
             IF_RF24ETHERNET_DEBUG_CLIENT(Serial.println(); Serial.print(millis()); Serial.println("UIP Client close(timeout)"););
+        }else{
+          if(!u->initialData){
+            u->connectTimer = millis();
+            u->initialData = true;
+          }
         }
     }
+#endif
 
     /*******Connected**********/
     if (!u && uip_connected())
@@ -254,7 +262,9 @@ void serialip_appcall(void)
         IF_RF24ETHERNET_DEBUG_CLIENT(Serial.println(); Serial.print(millis()); Serial.println(F(" UIPClient uip_connected")););
 
         u = (uip_userdata_t*)EthernetClient::_allocateData();
-
+        #if UIP_CONNECTION_TIMEOUT > 0
+          u->connectTimer = millis();
+        #endif
         if (u)
         {
             uip_conn->appstate = u;
@@ -272,8 +282,9 @@ void serialip_appcall(void)
         if (uip_newdata())
         {
             IF_RF24ETHERNET_DEBUG_CLIENT(Serial.println(); Serial.print(millis()); Serial.print(F(" UIPClient uip_newdata, uip_len:")); Serial.println(uip_len););
-
-            u->initialData = true;
+            #if UIP_CONNECTION_TIMEOUT > 0
+              u->connectTimer = millis();
+            #endif
 
             if (u->sent)
             {
@@ -284,7 +295,7 @@ void serialip_appcall(void)
                 uip_stop();
                 u->state &= ~UIP_CLIENT_RESTART;
                 u->windowOpened = false;
-                u->connAbortTime = u->restartTime = millis();
+                u->restartTime = millis();
                 memcpy(&u->myData[u->dataPos + u->dataCnt], uip_appdata, uip_datalen());
                 u->dataCnt += uip_datalen();
 
@@ -324,7 +335,10 @@ void serialip_appcall(void)
             IF_RF24ETHERNET_DEBUG_CLIENT(Serial.println(); Serial.print(millis()); Serial.println(F(" UIPClient uip_acked")););
             u->state &= ~UIP_CLIENT_RESTART;
             u->hold = (u->out_pos = (u->windowOpened = (u->packets_out = false)));
-            u->connAbortTime = (u->restartTime = millis());
+            u->restartTime = millis();
+            #if UIP_CONNECTION_TIMEOUT > 0
+            u->connectTimer = millis();
+            #endif
         }
 
         /*******Polling**********/
@@ -350,36 +364,17 @@ void serialip_appcall(void)
                 if (u->windowOpened == true && u->state & UIP_CLIENT_RESTART && millis() - u->restartTime > u->restartInterval)
                 {
                     u->restartTime = millis();
-// Abort the connection if the connection is dead after a set timeout period (uip-conf.h)
-#if defined UIP_CONNECTION_TIMEOUT
-                    if (millis() - u->connAbortTime >= UIP_CONNECTION_TIMEOUT)
-                    {
-    #if defined RF24ETHERNET_DEBUG_CLIENT || defined ETH_DEBUG_L1
-                        Serial.println();
-                        Serial.print(millis());
-                        Serial.println(F(" *********** ABORTING CONNECTION ***************"));
-    #endif
-                        u->windowOpened = false;
-                        u->state = 0;
-                        uip_conn->appstate = NULL;
-                        uip_abort();
-                        goto finish;
-                    }
-                    else
-                    {
-#endif
 #if defined RF24ETHERNET_DEBUG_CLIENT || defined ETH_DEBUG_L1
                         Serial.println();
                         Serial.print(millis());
-                        Serial.print(F(" UIPClient Re-Open TCP Window, time remaining before abort: "));
-                        Serial.println((UIP_CONNECTION_TIMEOUT - (millis() - u->connAbortTime)) / 1000.00);
+                        #if UIP_CONNECTION_TIMEOUT > 0
+                          Serial.print(F(" UIPClient Re-Open TCP Window, time remaining before abort: "));
+                          Serial.println(  UIP_CONNECTION_TIMEOUT - (millis() - u->connectTimer));
+                        #endif
 #endif
-                        u->restartInterval += 500;
-                        u->restartInterval = rf24_min(u->restartInterval, 7000);
-                        uip_restart();
-#if defined UIP_CONNECTION_TIMEOUT
-                    }
-#endif
+                    u->restartInterval += 500;
+                    u->restartInterval = rf24_min(u->restartInterval, 7000);
+                    uip_restart();
                 }
             }
         }
@@ -416,7 +411,7 @@ finish:;
 #endif
                 u->windowOpened = true;
                 u->restartInterval = UIP_WINDOW_REOPEN_DELAY; //.75 seconds
-                u->restartTime = u->connAbortTime = millis();
+                u->restartTime = millis();
             }
         }
     }
@@ -439,7 +434,10 @@ uip_userdata_t* RF24Client::_allocateData()
             data->out_pos = 0;
             data->hold = 0;
             data->initialData = false;
-            data->connectTimer = millis();
+            #if (UIP_CONNECTION_TIMEOUT > 0)
+              data->connectTimer = millis();
+              data->connectTimeout = UIP_CONNECTION_TIMEOUT;
+            #endif
             return data;
         }
     }

--- a/RF24Client.cpp
+++ b/RF24Client.cpp
@@ -262,11 +262,12 @@ void serialip_appcall(void)
         IF_RF24ETHERNET_DEBUG_CLIENT(Serial.println(); Serial.print(millis()); Serial.println(F(" UIPClient uip_connected")););
 
         u = (uip_userdata_t*)EthernetClient::_allocateData();
-        #if UIP_CONNECTION_TIMEOUT > 0
-          u->connectTimer = millis();
-        #endif
+
         if (u)
         {
+            #if UIP_CONNECTION_TIMEOUT > 0
+              u->connectTimer = millis();
+            #endif
             uip_conn->appstate = u;
             IF_RF24ETHERNET_DEBUG_CLIENT(Serial.print(F("UIPClient allocated state: ")); Serial.println(u->state, BIN););
         }

--- a/RF24Client.h
+++ b/RF24Client.h
@@ -66,9 +66,10 @@ typedef struct
 #endif
     uint32_t restartTime;
     uint32_t restartInterval;
-    uint32_t connAbortTime;
+#if UIP_CONNECTION_TIMEOUT > 0
     uint32_t connectTimeout;
     uint32_t connectTimer;
+#endif
     uint8_t myData[OUTPUT_BUFFER_SIZE];
     bool initialData;
 } uip_userdata_t;

--- a/RF24Ethernet.cpp
+++ b/RF24Ethernet.cpp
@@ -220,8 +220,8 @@ void RF24EthernetClass::tick()
     yield();
 #endif
 #if defined(ARDUINO_ARCH_ESP32)
-  const TickType_t xDelay = 1 / portTICK_PERIOD_MS;
-  vTaskDelay( xDelay );
+    const TickType_t xDelay = 1 / portTICK_PERIOD_MS;
+    vTaskDelay(xDelay);
 #endif
 
     if (RF24Ethernet.network.update() == EXTERNAL_DATA_TYPE) {

--- a/RF24Ethernet.h
+++ b/RF24Ethernet.h
@@ -20,7 +20,7 @@
   */
 
 #ifndef RF24Ethernet_h
-    #define RF24Ethernet_h
+#define RF24Ethernet_h
 
 /**
  * @file RF24Ethernet.h
@@ -28,68 +28,68 @@
  * Class declaration for RF24Ethernet
  */
 
-    #include <Arduino.h>
+#include <Arduino.h>
 
 extern "C" {
-    #include "uip-conf.h"
-    #include "utility/uip.h"
-    #include "utility/uiptimer.h"
-    #include "utility/uip_arp.h"
+#include "uip-conf.h"
+#include "utility/uip.h"
+#include "utility/uiptimer.h"
+#include "utility/uip_arp.h"
 }
 
-    #include "RF24Ethernet_config.h"
-    #if defined (ARDUINO_ARCH_NRF52) || defined (ARDUINO_ARCH_NRF52840) || defined (ARDUINO_ARCH_NRF52833)
-        #include <nrf_to_nrf.h>
-    #endif
-    #include <RF24.h>
-    #include <RF24Network.h>
-    #if !defined(RF24_TAP) // Using RF24Mesh
-        #include <RF24Mesh.h>
-    #endif
+#include "RF24Ethernet_config.h"
+#if defined(ARDUINO_ARCH_NRF52) || defined(ARDUINO_ARCH_NRF52840) || defined(ARDUINO_ARCH_NRF52833)
+    #include <nrf_to_nrf.h>
+#endif
+#include <RF24.h>
+#include <RF24Network.h>
+#if !defined(RF24_TAP) // Using RF24Mesh
+    #include <RF24Mesh.h>
+#endif
 
-    #include "ethernet_comp.h"
-    #include "IPAddress.h"
-    #include "RF24Client.h"
-    #include "RF24Server.h"
+#include "ethernet_comp.h"
+#include "IPAddress.h"
+#include "RF24Client.h"
+#include "RF24Server.h"
 
-    #if UIP_CONF_UDP > 0
-        #include "RF24Udp.h"
-        #include "Dns.h"
-    #endif
+#if UIP_CONF_UDP > 0
+    #include "RF24Udp.h"
+    #include "Dns.h"
+#endif
 
-    #define UIPETHERNET_FREEPACKET 1
-    #define UIPETHERNET_SENDPACKET 2
+#define UIPETHERNET_FREEPACKET 1
+#define UIPETHERNET_SENDPACKET 2
 
-    //#define TUN  // Use only the tcp protocol, no ethernet headers or arps
-    #define TAP // Include ethernet headers
+//#define TUN  // Use only the tcp protocol, no ethernet headers or arps
+#define TAP // Include ethernet headers
 
-    #if defined(TAP)
-        #define BUF ((struct uip_eth_hdr*)&uip_buf[0])
-    #endif
+#if defined(TAP)
+    #define BUF ((struct uip_eth_hdr*)&uip_buf[0])
+#endif
 //#define BUF ((struct uip_tcpip_hdr *)&uip_buf[UIP_LLH_LEN])
 
-    #define uip_seteth_addr(eaddr)          \
-        do {                                \
-            uip_ethaddr.addr[0] = eaddr[0]; \
-            uip_ethaddr.addr[1] = eaddr[1]; \
-            uip_ethaddr.addr[2] = eaddr[2]; \
-            uip_ethaddr.addr[3] = eaddr[3]; \
-            uip_ethaddr.addr[4] = eaddr[4]; \
-            uip_ethaddr.addr[5] = eaddr[5]; \
-        } while (0)
-    #define uip_ip_addr(addr, ip) memcpy(addr, &ip[0], 4)
+#define uip_seteth_addr(eaddr)          \
+    do {                                \
+        uip_ethaddr.addr[0] = eaddr[0]; \
+        uip_ethaddr.addr[1] = eaddr[1]; \
+        uip_ethaddr.addr[2] = eaddr[2]; \
+        uip_ethaddr.addr[3] = eaddr[3]; \
+        uip_ethaddr.addr[4] = eaddr[4]; \
+        uip_ethaddr.addr[5] = eaddr[5]; \
+    } while (0)
+#define uip_ip_addr(addr, ip) memcpy(addr, &ip[0], 4)
 
-    #define ip_addr_uip(a) IPAddress(a[0] & 0xFF, a[0] >> 8, a[1] & 0xFF, a[1] >> 8) // TODO this is not IPV6 capable
+#define ip_addr_uip(a) IPAddress(a[0] & 0xFF, a[0] >> 8, a[1] & 0xFF, a[1] >> 8) // TODO this is not IPV6 capable
 
-    #define uip_seteth_addr(eaddr)          \
-        do {                                \
-            uip_ethaddr.addr[0] = eaddr[0]; \
-            uip_ethaddr.addr[1] = eaddr[1]; \
-            uip_ethaddr.addr[2] = eaddr[2]; \
-            uip_ethaddr.addr[3] = eaddr[3]; \
-            uip_ethaddr.addr[4] = eaddr[4]; \
-            uip_ethaddr.addr[5] = eaddr[5]; \
-        } while (0)
+#define uip_seteth_addr(eaddr)          \
+    do {                                \
+        uip_ethaddr.addr[0] = eaddr[0]; \
+        uip_ethaddr.addr[1] = eaddr[1]; \
+        uip_ethaddr.addr[2] = eaddr[2]; \
+        uip_ethaddr.addr[3] = eaddr[3]; \
+        uip_ethaddr.addr[4] = eaddr[4]; \
+        uip_ethaddr.addr[5] = eaddr[5]; \
+    } while (0)
 
 /**
  * @warning <b>This is used internally. Use IPAddress instead. </b>
@@ -99,7 +99,6 @@ typedef struct
     int a, b, c, d;
 } IP_ADDR;
 
-
 class RF24;
 template<class radio_t>
 class ESB_Network;
@@ -107,22 +106,22 @@ class ESB_Network;
 class RF24EthernetClass
 { //: public Print {
 public:
-    /**
-     * Constructor to set up the Ethernet layer. Requires the radio and network to be configured by the user
-     * this allows users to set custom settings at the radio or network level
-     */
-    #if !defined(RF24_TAP) // Using RF24Mesh
+/**
+ * Constructor to set up the Ethernet layer. Requires the radio and network to be configured by the user
+ * this allows users to set custom settings at the radio or network level
+ */
+#if !defined(RF24_TAP) // Using RF24Mesh
     RF24EthernetClass(RF24& _radio, RF24Network& _network, RF24Mesh& _mesh);
-    #else
+#else
     RF24EthernetClass(RF24& _radio, RF24Network& _network);
-    #endif
-    #if defined NRF52_RADIO_LIBRARY
-        #if !defined(RF24_TAP)
+#endif
+#if defined NRF52_RADIO_LIBRARY
+    #if !defined(RF24_TAP)
     RF24EthernetClass(nrf_to_nrf& _radio, RF52Network& _network, RF52Mesh& _mesh);
-        #else
+    #else
     RF24EthernetClass(nrf_to_nrf& _radio, RF52Network& _network);
-        #endif
     #endif
+#endif
 
     /** Basic constructor */
     RF24EthernetClass();
@@ -191,22 +190,22 @@ public:
     // uint8_t *key;
 
 private:
-    #if defined NRF52_RADIO_LIBRARY
+#if defined NRF52_RADIO_LIBRARY
     nrf_to_nrf& radio;
-    #else
+#else
     RF24& radio;
+#endif
+#if !defined NRF52_RADIO_LIBRARY
+    RF24Network& network;
+    #if !defined(RF24_TAP) // Using RF24Mesh
+    RF24Mesh& mesh;
     #endif
-    #if !defined NRF52_RADIO_LIBRARY    
-      RF24Network& network;
-      #if !defined(RF24_TAP) // Using RF24Mesh
-      RF24Mesh& mesh;
-      #endif
-    #else
-      RF52Network& network;
-      #if !defined(RF24_TAP) // Using RF24Mesh
-      RF52Mesh& mesh;
-      #endif
+#else
+    RF52Network& network;
+    #if !defined(RF24_TAP) // Using RF24Mesh
+    RF52Mesh& mesh;
     #endif
+#endif
 
     static IPAddress _dnsServerAddress;
     void configure(IPAddress ip, IPAddress dns, IPAddress gateway, IPAddress subnet);
@@ -219,9 +218,9 @@ private:
     uint8_t RF24_Channel;
 
     struct timer periodic_timer;
-    #if defined RF24_TAP
+#if defined RF24_TAP
     struct timer arp_timer;
-    #endif
+#endif
     friend class RF24Server;
     friend class RF24Client;
     friend class RF24UDP;
@@ -230,7 +229,6 @@ private:
 extern RF24EthernetClass RF24Ethernet;
 
 typedef RF24EthernetClass RF52EthernetClass;
-
 
 /**
  * @example Getting_Started_SimpleServer_Mesh.ino
@@ -293,6 +291,5 @@ typedef RF24EthernetClass RF52EthernetClass;
  * <br>This example uses [HTML.h](SLIP__InteractiveServer_2HTML_8h.html) from the
  * example's directory.
  */
- 
- #endif // RF24Ethernet_h
- 
+
+#endif // RF24Ethernet_h

--- a/RF24Server.cpp
+++ b/RF24Server.cpp
@@ -86,12 +86,12 @@ size_t RF24Server::write(const uint8_t* buf, size_t size)
 
 void RF24Server::setTimeout(uint32_t timeout)
 {
-    #if UIP_CONNECTION_TIMEOUT > 0
+#if UIP_CONNECTION_TIMEOUT > 0
     for (uint8_t i = 0; i < UIP_CONNS; i++) {
         uip_userdata_t* data = &RF24Client::all_data[i];
         if (data) {
             data->connectTimeout = timeout;
         }
     }
-    #endif
+#endif
 }

--- a/RF24Server.cpp
+++ b/RF24Server.cpp
@@ -82,12 +82,16 @@ size_t RF24Server::write(const uint8_t* buf, size_t size)
     return ret;
 }
 
+/*************************************************************/
+
 void RF24Server::setTimeout(uint32_t timeout)
 {
+    #if UIP_CONNECTION_TIMEOUT > 0
     for (uint8_t i = 0; i < UIP_CONNS; i++) {
         uip_userdata_t* data = &RF24Client::all_data[i];
         if (data) {
             data->connectTimeout = timeout;
         }
     }
+    #endif
 }

--- a/RF24Udp.cpp
+++ b/RF24Udp.cpp
@@ -115,7 +115,7 @@ int RF24UDP::beginPacket(IPAddress ip, uint16_t port)
         if (appdata.packet_out == 0)
         {
             appdata.packet_out = 1;
-            appdata.out_pos = 0; //UIP_UDP_PHYH_LEN;
+            appdata.out_pos = 0; // UIP_UDP_PHYH_LEN;
             if (appdata.packet_out != 0)
             {
                 return 1;
@@ -212,10 +212,10 @@ int RF24UDP::parsePacket()
 
     IF_RF24ETHERNET_DEBUG_UDP(if (appdata.packet_in != 0) { Serial.print(F("RF24UDP udp parsePacket freeing previous packet: ")); Serial.println(appdata.packet_in); });
 
-    //appdata.packet_in_size = 0;
+    // appdata.packet_in_size = 0;
 
-    //appdata.packet_in = appdata.packet_next;
-    //appdata.packet_next = 0;
+    // appdata.packet_in = appdata.packet_next;
+    // appdata.packet_next = 0;
 
     IF_RF24ETHERNET_DEBUG_UDP(if (appdata.packet_in != 0) { Serial.print(F("RF24UDP udp parsePacket received packet: ")); Serial.print(appdata.packet_in); } Serial.print(F(", size: ")); Serial.println(size););
 
@@ -324,7 +324,7 @@ void uipudp_appcall(void)
                 uip_udp_conn->rport = UDPBUF->srcport;
                 uip_ipaddr_copy(uip_udp_conn->ripaddr, UDPBUF->srcipaddr);
 
-                //discard Linklevel and IP and udp-header and any trailing bytes:
+                // discard Linklevel and IP and udp-header and any trailing bytes:
                 memcpy(RF24Client::all_data[0].myData, uip_appdata, uip_len);
                 data->packet_in_size += uip_len;
                 data->packet_in = 1;
@@ -334,7 +334,7 @@ void uipudp_appcall(void)
         }
         if (uip_poll() && data->send)
         {
-            //set uip_slen (uip private) by calling uip_udp_send
+            // set uip_slen (uip private) by calling uip_udp_send
             IF_RF24ETHERNET_DEBUG_UDP(Serial.print(F("udp, uip_poll preparing packet to send: ")); Serial.print(data->packet_out); Serial.print(F(", size: ")); Serial.println(data->out_pos););
 
             memcpy(uip_appdata, RF24Client::all_data[0].myData, data->out_pos);
@@ -348,22 +348,22 @@ void uipudp_appcall(void)
 void RF24UDP::_send(uip_udp_userdata_t* data)
 {
         #if defined(RF24_TAP)
-    uip_arp_out(); //add arp
+    uip_arp_out(); // add arp
         #endif
     if (uip_len == UIP_ARPHDRSIZE)
     {
-        //RF24EthernetClass::uip_packet = 0;
-        //RF24EthernetClass::packetstate &= ~UIPETHERNET_SENDPACKET;
+        // RF24EthernetClass::uip_packet = 0;
+        // RF24EthernetClass::packetstate &= ~UIPETHERNET_SENDPACKET;
 
         IF_RF24ETHERNET_DEBUG_UDP(Serial.println(F("udp, uip_poll results in ARP-packet")););
         RF24EthernetClass::network_send();
     }
     else
     {
-        //arp found ethaddr for ip (otherwise packet is replaced by arp-request)
+        // arp found ethaddr for ip (otherwise packet is replaced by arp-request)
         data->send = false;
         data->packet_out = 0;
-        //RF24EthernetClass::packetstate |= UIPETHERNET_SENDPACKET;
+        // RF24EthernetClass::packetstate |= UIPETHERNET_SENDPACKET;
         IF_RF24ETHERNET_DEBUG_UDP(Serial.println(data->out_pos); Serial.print(F("udp, uip_packet to send: ")); for (int i = 0; i < data->out_pos; i++) { Serial.print((char)RF24Client::all_data[0].myData[i]); } Serial.println(""););
 
         RF24NetworkHeader headerOut(00, EXTERNAL_DATA_TYPE);

--- a/uip-conf.h
+++ b/uip-conf.h
@@ -186,7 +186,7 @@
     #define UIP_CONF_RECEIVE_WINDOW 511
 #else
     //#define UIP_CONF_RECEIVE_WINDOW UIP_CONF_BUFFER_SIZE *2 - UIP_CONF_LLH_LEN - UIP_TCPIP_HLEN //This is set automatically to the max allowable size
-    #define UIP_CONF_RECEIVE_WINDOW UIP_CONF_BUFFER_SIZE - UIP_CONF_LLH_LEN - UIP_TCPIP_HLEN //This is set automatically to the max allowable size
+    #define UIP_CONF_RECEIVE_WINDOW UIP_CONF_BUFFER_SIZE - UIP_CONF_LLH_LEN - UIP_TCPIP_HLEN // This is set automatically to the max allowable size
 #endif
 
 #define UIP_CONF_TCP_MSS OUTPUT_BUFFER_SIZE

--- a/uip-conf.h
+++ b/uip-conf.h
@@ -87,7 +87,7 @@
  *
  * If uIP is polling the established connection, but an ack or data is not received for this duration in ms, kill the connection.
  */
-#define UIP_CONNECTION_TIMEOUT 30000
+#define UIP_CONNECTION_TIMEOUT 45000
 
 /**
  * @brief SLIP/TUN - 14 for Ethernet/TAP & 0 for TUN/SLIP


### PR DESCRIPTION
- Add timeouts for both clients and servers by default
- Change default timeout period to 45 seconds
- Remove 4-bytes from userdata struct (connAbortTime)
- Server-side timeouts were not working by default, now they are. Set `UIP_CONNECTION_TIMEOUT` in uip-conf.h to a higher value or 0 to disable

Was finding an issue I noticed in the past with the default behaviour of servers hanging up if they experienced a disconnect etc. The solution was to manually set a timeout, but it was not enabled by default. This sets it up by default to timeout of data is not received or acked in 45 seconds and simplifies the code. 