### PR TITLE
Simplify connection timeouts more

### DIFF
--- a/RF24Client.h
+++ b/RF24Client.h
@@ -71,7 +71,6 @@ typedef struct
     uint32_t connectTimer;
 #endif
     uint8_t myData[OUTPUT_BUFFER_SIZE];
-    bool initialData;
 } uip_userdata_t;
 
 class RF24Client : public Client


### PR DESCRIPTION
Kind of hate to do another PR right away like this, but I will give this one a while before merging in case I find any other optimizations etc.

- Realized that the timeout var is set when data is allocated initially
- No need for initialData variable
- Move connection timeout after data is allocated (timeout is set to millis())