### PR TITLE
Fix URL in client examples

### DIFF
--- a/examples/Getting_Started_SimpleClient_Mesh/Getting_Started_SimpleClient_Mesh.ino
+++ b/examples/Getting_Started_SimpleClient_Mesh/Getting_Started_SimpleClient_Mesh.ino
@@ -90,8 +90,8 @@ EthernetClient client;
 // The hosts we will be connecting to
 // Note: The gateway will need to be able to forward traffic for internet hosts, see the documentation
 IPAddress icewind(109, 120, 203, 163);  //http://109.120.203.163/web/blyad.club/library/litrature/Salvatore,%20R.A/Salvatore,%20R.A%20-%20Icewind%20Dale%20Trilogy%201%20-%20Crystal%20Shard,%20The.txt
-IPAddress pizza(94, 199, 58, 243);      //http://fiikus.net/asciiart/pizza.txt
-IPAddress host(pizza);
+IPAddress ascii(208, 86, 224, 90);      //http://artscene.textfiles.com/asciiart/texthistory.txt
+IPAddress host(ascii);
 
 void setup() {
 
@@ -120,7 +120,7 @@ void loop() {
   if (Serial.available()) {
     char c = Serial.read();
     if (c == 'p') {
-      host = pizza;
+      host = ascii;
     } else if (c == 'g') {
       host = icewind;
     }
@@ -172,8 +172,9 @@ void connect() {
     Serial.println(F("connected"));
 
     // Make an HTTP request:
-    if (host == pizza) {
-      client.write("GET /asciiart/pizza.txt HTTP/1.1\nHost: fiikus.net\n");
+    if (host == ascii) {
+      client.println("GET http://artscene.textfiles.com/asciiart/texthistory.txt HTTP/1.1");
+      client.println("Host: 208.86.224.90");
     } else {
       client.println("GET /web/blyad.club/library/litrature/Salvatore,%20R.A/Salvatore,%20R.A%20-%20Icewind%20Dale%20Trilogy%201%20-%20Crystal%20Shard,%20The.txt HTTP/1.1");
       client.println("Host: 109.120.203.163");

--- a/examples/Getting_Started_SimpleClient_Mesh_DNS/Getting_Started_SimpleClient_Mesh_DNS.ino
+++ b/examples/Getting_Started_SimpleClient_Mesh_DNS/Getting_Started_SimpleClient_Mesh_DNS.ino
@@ -30,7 +30,7 @@ EthernetClient client;
 // Note: The gateway will need to be able to forward traffic for internet hosts, see the documentation
 // Note: DNS responses for www.domain.com will typically be shorter than requests for domain.com.
 char icewind[] = { "109.120.203.163" };  //http://109.120.203.163/web/blyad.club/library/litrature/Salvatore,%20R.A/Salvatore,%20R.A%20-%20Icewind%20Dale%20Trilogy%201%20-%20Crystal%20Shard,%20The.txt
-char ascii[] = { "artscene.textfiles.com" };     //http://artscene.textfiles.com/asciiart/texthistory.txt
+char ascii[] = { "artscene.textfiles.com" };  //http://artscene.textfiles.com/asciiart/texthistory.txt
 char* host = ascii;
 
 void setup() {

--- a/examples/Getting_Started_SimpleClient_Mesh_DNS/Getting_Started_SimpleClient_Mesh_DNS.ino
+++ b/examples/Getting_Started_SimpleClient_Mesh_DNS/Getting_Started_SimpleClient_Mesh_DNS.ino
@@ -30,8 +30,8 @@ EthernetClient client;
 // Note: The gateway will need to be able to forward traffic for internet hosts, see the documentation
 // Note: DNS responses for www.domain.com will typically be shorter than requests for domain.com.
 char icewind[] = { "109.120.203.163" };  //http://109.120.203.163/web/blyad.club/library/litrature/Salvatore,%20R.A/Salvatore,%20R.A%20-%20Icewind%20Dale%20Trilogy%201%20-%20Crystal%20Shard,%20The.txt
-char pizza[] = { "www.fiikus.net" };     //http://fiikus.net/asciiart/pizza.txt
-char* host = pizza;
+char ascii[] = { "artscene.textfiles.com" };     //http://artscene.textfiles.com/asciiart/texthistory.txt
+char* host = ascii;
 
 void setup() {
 
@@ -43,7 +43,7 @@ void setup() {
   IPAddress myIP(10, 10, 2, 4);
   IPAddress myDNS(8, 8, 8, 8);  //Use Google DNS in this example
   Ethernet.begin(myIP, myDNS);
-  mesh.begin(30);
+  mesh.begin();
 
   // If you'll be making outgoing connections from the Arduino to the rest of
   // the world, you'll need a gateway set up.
@@ -61,7 +61,7 @@ void loop() {
   if (Serial.available()) {
     char c = Serial.read();
     if (c == 'p') {
-      host = pizza;
+      host = ascii;
     } else if (c == 'g') {
       host = icewind;
     }
@@ -113,8 +113,9 @@ void connect() {
     Serial.println(F("connected"));
 
     // Make an HTTP request:
-    if (host == pizza) {
-      client.write("GET /asciiart/pizza.txt HTTP/1.1\nHost: fiikus.net\n");
+    if (host == ascii) {
+      client.println("GET http://artscene.textfiles.com/asciiart/texthistory.txt HTTP/1.1");
+      client.println("Host: 208.86.224.90");
     } else {
       client.println("GET /web/blyad.club/library/litrature/Salvatore,%20R.A/Salvatore,%20R.A%20-%20Icewind%20Dale%20Trilogy%201%20-%20Crystal%20Shard,%20The.txt HTTP/1.1");
       client.println("Host: 109.120.203.163");

--- a/examples/SimpleClient_Mesh/SimpleClient_Mesh.ino
+++ b/examples/SimpleClient_Mesh/SimpleClient_Mesh.ino
@@ -123,14 +123,15 @@ void loop() {
 
 void connect() {
   Serial.println(F("connecting"));
-  IPAddress pizza(94, 199, 58, 243);
-  if (client.connect(pizza, 80)) {
+  IPAddress ascii(208, 86, 224, 90);
+  if (client.connect(ascii, 80)) {
     Serial.println(F("connected"));
 
     // Make an HTTP request:
-    client.write("GET /asciiart/pizza.txt HTTP/1.1\n");
-    client.write("Host: fiikus.net\n");
-    client.write("Connection: close\n\n");
+    client.println("GET http://artscene.textfiles.com/asciiart/texthistory.txt HTTP/1.1");
+    client.println("Host: 208.86.224.90");
+    client.println("Connection: close");
+    client.println();
   } else {
     // if you didn't get a connection to the server:
     Serial.println(F("connection failed"));


### PR DESCRIPTION
- Change URL in client examples from http://fiikus.net/asciiart/pizza.txt to  http://artscene.textfiles.com/asciiart/texthistory.txt
- Found DNS example was using channel 30 by default, revert back to default channel