### PR TITLE
Fixes: rexmit mechanism & hold

### DIFF
--- a/RF24Client.cpp
+++ b/RF24Client.cpp
@@ -336,7 +336,7 @@ void serialip_appcall(void)
         if (uip_poll() || uip_rexmit())
         {
             if (uip_rexmit()) {
-                IF_RF24ETHERNET_DEBUG_CLIENT(Serial.println(F("ReXmit, Len: ")););
+                IF_RF24ETHERNET_DEBUG_CLIENT(Serial.print(F("ReXmit, Len: ")););
                 IF_RF24ETHERNET_DEBUG_CLIENT(Serial.println(u->data_pos));
                 uip_len = u->data_pos;
                 uip_send(u->myData, u->data_pos);

--- a/RF24Client.cpp
+++ b/RF24Client.cpp
@@ -196,16 +196,16 @@ test2:
     if (u && !(u->state & (UIP_CLIENT_CLOSE | UIP_CLIENT_REMOTECLOSED)) && u->state & (UIP_CLIENT_CONNECTED))
     {
 
-        if (u->out_pos + payloadSize > UIP_TCP_MSS || u->hold)
+        if (u->data_pos + payloadSize > UIP_TCP_MSS || u->hold)
         {
             goto test2;
         }
 
-        IF_RF24ETHERNET_DEBUG_CLIENT(Serial.println(); Serial.print(millis()); Serial.print(F(" UIPClient.write: writePacket(")); Serial.print(u->packets_out); Serial.print(F(") pos: ")); Serial.print(u->out_pos); Serial.print(F(", buf[")); Serial.print(size - total_written); Serial.print(F("]: '")); Serial.write((uint8_t*)buf + total_written, payloadSize); Serial.println(F("'")););
+        IF_RF24ETHERNET_DEBUG_CLIENT(Serial.println(); Serial.print(millis()); Serial.print(F(" UIPClient.write: writePacket(")); Serial.print(u->packets_out); Serial.print(F(") pos: ")); Serial.print(u->data_pos); Serial.print(F(", buf[")); Serial.print(size - total_written); Serial.print(F("]: '")); Serial.write((uint8_t*)buf + total_written, payloadSize); Serial.println(F("'")););
 
-        memcpy(u->myData + u->out_pos, buf + total_written, payloadSize);
+        memcpy(u->myData + u->data_pos, buf + total_written, payloadSize);
         u->packets_out = 1;
-        u->out_pos += payloadSize;
+        u->data_pos += payloadSize;
 
         total_written += payloadSize;
 
@@ -217,7 +217,8 @@ test2:
             // RF24EthernetClass::tick();
             goto test2;
         }
-        return u->out_pos;
+        u->hold = false;
+        return u->data_pos;
     }
     u->hold = false;
     return -1;
@@ -278,18 +279,15 @@ void serialip_appcall(void)
 #if UIP_CONNECTION_TIMEOUT > 0
             u->connectTimer = millis();
 #endif
+            u->hold = (u->data_pos = (u->windowOpened = (u->packets_out = false)));
 
-            if (u->sent)
-            {
-                u->hold = (u->out_pos = (u->windowOpened = (u->packets_out = false)));
-            }
             if (uip_len && !(u->state & (UIP_CLIENT_CLOSE | UIP_CLIENT_REMOTECLOSED)))
             {
                 uip_stop();
                 u->state &= ~UIP_CLIENT_RESTART;
                 u->windowOpened = false;
                 u->restartTime = millis();
-                memcpy(&u->myData[u->dataPos + u->dataCnt], uip_appdata, uip_datalen());
+                memcpy(&u->myData[u->data_pos + u->dataCnt], uip_appdata, uip_datalen());
                 u->dataCnt += uip_datalen();
 
                 u->packets_in = 1;
@@ -327,7 +325,7 @@ void serialip_appcall(void)
         {
             IF_RF24ETHERNET_DEBUG_CLIENT(Serial.println(); Serial.print(millis()); Serial.println(F(" UIPClient uip_acked")););
             u->state &= ~UIP_CLIENT_RESTART;
-            u->hold = (u->out_pos = (u->windowOpened = (u->packets_out = false)));
+            u->hold = (u->data_pos = (u->windowOpened = (u->packets_out = false)));
             u->restartTime = millis();
 #if UIP_CONNECTION_TIMEOUT > 0
             u->connectTimer = millis();
@@ -337,39 +335,46 @@ void serialip_appcall(void)
         /*******Polling**********/
         if (uip_poll() || uip_rexmit())
         {
-            // IF_RF24ETHERNET_DEBUG_CLIENT( Serial.println(); Serial.println(F("UIPClient uip_poll")); );
-
-            if (u->packets_out != 0)
-            {
-                uip_len = u->out_pos;
-                uip_send(u->myData, u->out_pos);
+            if (uip_rexmit()) {
+                IF_RF24ETHERNET_DEBUG_CLIENT(Serial.println(F("ReXmit, Len: ")););
+                IF_RF24ETHERNET_DEBUG_CLIENT(Serial.println(u->data_pos));
+                uip_len = u->data_pos;
+                uip_send(u->myData, u->data_pos);
                 u->hold = true;
-                u->sent = true;
                 goto finish;
             }
-            else
-                // Restart mechanism to keep connections going
-                // Only call this if the TCP window has already been re-opened, the connection is being polled, but no data
-                // has been acked
-                if (!(u->state & (UIP_CLIENT_CLOSE | UIP_CLIENT_REMOTECLOSED)))
-                {
+            // IF_RF24ETHERNET_DEBUG_CLIENT( Serial.println(); Serial.println(F("UIPClient uip_poll")); );
 
-                    if (u->windowOpened == true && u->state & UIP_CLIENT_RESTART && millis() - u->restartTime > u->restartInterval)
-                    {
-                        u->restartTime = millis();
+            if (u->packets_out != 0 && !u->hold)
+            {
+                uip_len = u->data_pos;
+                uip_send(u->myData, u->data_pos);
+                u->hold = true;
+                goto finish;
+            }
+
+            // Restart mechanism to keep connections going
+            // Only call this if the TCP window has already been re-opened, the connection is being polled, but no data
+            // has been acked
+            if (!(u->state & (UIP_CLIENT_CLOSE | UIP_CLIENT_REMOTECLOSED)))
+            {
+
+                if (u->windowOpened == true && u->state & UIP_CLIENT_RESTART && millis() - u->restartTime > u->restartInterval)
+                {
+                    u->restartTime = millis();
 #if defined RF24ETHERNET_DEBUG_CLIENT || defined ETH_DEBUG_L1
-                        Serial.println();
-                        Serial.print(millis());
+                    Serial.println();
+                    Serial.print(millis());
     #if UIP_CONNECTION_TIMEOUT > 0
-                        Serial.print(F(" UIPClient Re-Open TCP Window, time remaining before abort: "));
-                        Serial.println(UIP_CONNECTION_TIMEOUT - (millis() - u->connectTimer));
+                    Serial.print(F(" UIPClient Re-Open TCP Window, time remaining before abort: "));
+                    Serial.println(UIP_CONNECTION_TIMEOUT - (millis() - u->connectTimer));
     #endif
 #endif
-                        u->restartInterval += 500;
-                        u->restartInterval = rf24_min(u->restartInterval, 7000);
-                        uip_restart();
-                    }
+                    u->restartInterval += 500;
+                    u->restartInterval = rf24_min(u->restartInterval, 7000);
+                    uip_restart();
                 }
+            }
         }
 
         /*******Close**********/
@@ -423,9 +428,11 @@ uip_userdata_t* RF24Client::_allocateData()
             data->packets_in = 0;
             data->packets_out = 0;
             data->dataCnt = 0;
-            data->dataPos = 0;
-            data->out_pos = 0;
+            //data->dataPos = 0;
+            data->data_pos = 0;
             data->hold = 0;
+            data->restartTime = millis();
+            data->restartInterval = 5000;
 #if (UIP_CONNECTION_TIMEOUT > 0)
             data->connectTimer = millis();
             data->connectTimeout = UIP_CONNECTION_TIMEOUT;
@@ -483,15 +490,15 @@ int RF24Client::read(uint8_t* buf, size_t size)
         }
 
         size = rf24_min(data->dataCnt, size);
-        memcpy(buf, &data->myData[data->dataPos], size);
+        memcpy(buf, &data->myData[data->data_pos], size);
         data->dataCnt -= size;
 
-        data->dataPos += size;
+        data->data_pos += size;
 
         if (!data->dataCnt)
         {
             data->packets_in = 0;
-            data->dataPos = 0;
+            data->data_pos = 0;
 
             if (uip_stopped(&uip_conns[data->state & UIP_CLIENT_SOCKETS]) && !(data->state & (UIP_CLIENT_CLOSE | UIP_CLIENT_REMOTECLOSED)))
             {
@@ -536,7 +543,7 @@ int RF24Client::peek()
 {
     if (available())
     {
-        return data->myData[data->dataPos];
+        return data->myData[data->data_pos];
     }
     return -1;
 }

--- a/RF24Client.h
+++ b/RF24Client.h
@@ -57,7 +57,8 @@ typedef struct __attribute__((__packed__))
     bool packets_out;
     bool windowOpened;
     uint8_t state;
-    uint16_t data_pos;
+    uint16_t in_pos;
+    uint16_t out_pos;
     uint16_t dataCnt;
 #if UIP_CLIENT_TIMER >= 0
     uint32_t timer;

--- a/RF24Client.h
+++ b/RF24Client.h
@@ -50,7 +50,7 @@ typedef struct
  * Data structure for holding per connection data
  * @warning <b> This is used internally and should not be accessed directly by users </b>
  */
-typedef __attribute__((__packed__)) struct
+typedef struct __attribute__((__packed__))
 {
     bool hold;
     bool packets_in;

--- a/RF24Client.h
+++ b/RF24Client.h
@@ -50,16 +50,14 @@ typedef struct
  * Data structure for holding per connection data
  * @warning <b> This is used internally and should not be accessed directly by users </b>
  */
-typedef struct
+typedef __attribute__((__packed__)) struct
 {
     bool hold;
-    bool sent;
     bool packets_in;
     bool packets_out;
     bool windowOpened;
     uint8_t state;
-    uint16_t out_pos;
-    uint16_t dataPos;
+    uint16_t data_pos;
     uint16_t dataCnt;
 #if UIP_CLIENT_TIMER >= 0
     uint32_t timer;

--- a/RF24Ethernet.cpp
+++ b/RF24Ethernet.cpp
@@ -315,14 +315,15 @@ void RF24EthernetClass::network_send()
 {
     RF24NetworkHeader headerOut(00, EXTERNAL_DATA_TYPE);
 
-    bool ok = RF24Ethernet.network.write(headerOut, uip_buf, uip_len);
-
 #if defined ETH_DEBUG_L1 || defined ETH_DEBUG_L2
+    bool ok = RF24Ethernet.network.write(headerOut, uip_buf, uip_len);
     if (!ok) {
         Serial.println();
         Serial.print(millis());
         Serial.println(F(" *** RF24Ethernet Network Write Fail ***"));
     }
+#else
+        RF24Ethernet.network.write(headerOut, uip_buf, uip_len);
 #endif
 
 #if defined ETH_DEBUG_L2

--- a/RF24Ethernet.cpp
+++ b/RF24Ethernet.cpp
@@ -317,16 +317,13 @@ void RF24EthernetClass::network_send()
 
     bool ok = RF24Ethernet.network.write(headerOut, uip_buf, uip_len);
 
-    if (!ok) {
-        ok = RF24Ethernet.network.write(headerOut, uip_buf, uip_len);
 #if defined ETH_DEBUG_L1 || defined ETH_DEBUG_L2
-        if (!ok) {
-            Serial.println();
-            Serial.print(millis());
-            Serial.println(F(" *** RF24Ethernet Network Write Fail ***"));
-        }
-#endif
+    if (!ok) {
+        Serial.println();
+        Serial.print(millis());
+        Serial.println(F(" *** RF24Ethernet Network Write Fail ***"));
     }
+#endif
 
 #if defined ETH_DEBUG_L2
     if (ok) {


### PR DESCRIPTION
- Fix: re-transmit mechanism - this was not working if waiting for an ack due to the `hold` variable being set.
- Fix: `hold` variable was not being set or unset where it should be
- Remove out_pos & dataPos variables from userdata struct, replace with data_pos variable
- Add attribute_packed to the userdata struct since it is now mis-aligned
- Now only transmit one RF24Network payload instead of a retry, since the rexmit mechanism is now working

In summary, the UIP IP stack was calling the `rexmit()` function, but the `u->hold` variable would be set, so it wouldn't re-transmit, so I added some logic specific to the `rexmit()` function and it now works. The hold variable also wasn't always being set/unset when it should be, so I fixed that logic also.

This was all because my MQTT nodes weren't staying connected long enough, and they would mysteriously disconnect after random periods of time. It turns out that a single failure in communication would result in a timeout, so now that the retry mechanism is working, it should be much much longer before a node loses its connection to MQTT.

I also had the RF24Network layer re-transmitting if a payload failed, which could result in duplicate data/duplicate ping results, but that behaviour has been removed due to the rexmit mechanism of the IP stack working now.