### PR TITLE
Add renewAddress to MQTT examples if connect fails

### DIFF
--- a/.github/workflows/build_arduino.yml
+++ b/.github/workflows/build_arduino.yml
@@ -24,6 +24,7 @@ jobs:
         - examples/InteractiveServer_Mesh
         - examples/MQTT/mqtt_basic
         - examples/MQTT/mqtt_basic_2
+        - examples/MQTT/mqtt_basic_no_blk
         - examples/SimpleClient_Mesh
 
       # these need RF24_TAP defined
@@ -42,7 +43,6 @@ jobs:
         - source-url: https://github.com/nRF24/RF24.git
         - source-url: https://github.com/nRF24/RF24Network.git
         - source-url: https://github.com/nRF24/RF24Mesh.git
-        - name: PubSubClient
         - name: MQTT
         - source-path: ./
       fqbn: ${{ matrix.fqbn }}

--- a/.github/workflows/build_arduino.yml
+++ b/.github/workflows/build_arduino.yml
@@ -58,7 +58,6 @@ jobs:
       matrix:
         fqbn:
           - "arduino:avr:yun"
-          - "arduino:avr:uno"
           - "arduino:avr:diecimila"
           - "arduino:avr:mega"
           - "arduino:avr:megaADK"
@@ -102,9 +101,9 @@ jobs:
         # Generate size deltas data for this board
         include:
           - fqbn: arduino:avr:nano
-            enable-deltas-report: true
+            enable-deltas-report: ${{ github.event_name == 'pull_request' }}
           - fqbn: arduino:samd:mkrzero
-            enable-deltas-report: true
+            enable-deltas-report: ${{ github.event_name == 'pull_request' }}
 
   # When using a matrix to compile for multiple boards, it's necessary to use a separate job for the deltas report
   report:

--- a/.github/workflows/build_platformIO.yml
+++ b/.github/workflows/build_platformIO.yml
@@ -38,7 +38,7 @@ jobs:
     with:
       example-path: ${{ matrix.example }}
       board-id: ${{ matrix.board }}
-      lib-deps: -l knolleary/PubSubClient -l 256dpi/MQTT
+      lib-deps: -l 256dpi/MQTT
     strategy:
       fail-fast: false
       matrix:
@@ -48,6 +48,7 @@ jobs:
           - "examples/InteractiveServer_Mesh/*"
           - "examples/MQTT/mqtt_basic/mqtt_basic.ino"
           - "examples/MQTT/mqtt_basic_2/mqtt_basic_2.ino"
+          - "examples/MQTT/mqtt_basic_no_blk/mqtt_basic_no_blk.ino"
           - "examples/SimpleClient_Mesh/SimpleClient_Mesh.ino"
 
         # these need RF24_TAP defined

--- a/RF24Ethernet.h
+++ b/RF24Ethernet.h
@@ -273,6 +273,12 @@ typedef RF24EthernetClass RF52EthernetClass;
  */
 
 /**
+ * @example mqtt_basic_no_blk.ino
+ *
+ * This is similar to the mqtt_basic example, but uses a non-blocking connect function.
+ */
+ 
+/**
  * @example mqtt_basic_2.ino
  *
  * A copy of the initial MQTT example using MQTT library https://github.com/256dpi/arduino-mqtt/ slightly modified to include RF24Ethernet/RF24Mesh.

--- a/RF24Ethernet.h
+++ b/RF24Ethernet.h
@@ -277,7 +277,6 @@ typedef RF24EthernetClass RF52EthernetClass;
  *
  * This is similar to the mqtt_basic example, but uses a non-blocking connect function.
  */
- 
 /**
  * @example mqtt_basic_2.ino
  *

--- a/examples/MQTT/mqtt_basic/mqtt_basic.ino
+++ b/examples/MQTT/mqtt_basic/mqtt_basic.ino
@@ -59,17 +59,17 @@ MQTTClient client;
 
 void connect() {
   Serial.print("connecting...");
-  uint32_t clTimeout = millis();
+  uint32_t clTimeout = millis() + 5001;
   while (!client.connect(clientID)) {
     Serial.print(".");
-    if (millis() - clTimeout > 5001) {
+    if (millis() > clTimeout) {
       Serial.println();
       mesh.renewAddress();
       return;
     }
-    uint32_t timer = millis();
+    uint32_t timer = millis() + 1000;
     //Instead of delay, keep the RF24 stack updating
-    while (millis() - timer < 1000) {
+    while (millis() < timer) {
       Ethernet.update();
     }
   }
@@ -92,7 +92,6 @@ void setup() {
 
   //Convert the last octet of the IP address to an identifier used
   char str[4];
-  int test = ip[3];
   itoa(ip[3], str, 10);
   memcpy(&clientID[13], &str, strlen(str));
   Serial.println(clientID);
@@ -126,7 +125,6 @@ void loop() {
   if (client.connected() && millis() - pub_timer > 3000) {
     pub_timer = millis();
     char str[4];
-    int test = ip[3];
     itoa(ip[3], str, 10);
     char str1[] = "Node      \r\n";
     memcpy(&str1[5], &str, strlen(str));

--- a/examples/MQTT/mqtt_basic/mqtt_basic.ino
+++ b/examples/MQTT/mqtt_basic/mqtt_basic.ino
@@ -64,6 +64,7 @@ void connect() {
     Serial.print(".");
     if (millis() - clTimeout > 5001) {
       Serial.println();
+      mesh.renewAddress();
       return;
     }
     uint32_t timer = millis();

--- a/examples/MQTT/mqtt_basic_2/mqtt_basic_2.ino
+++ b/examples/MQTT/mqtt_basic_2/mqtt_basic_2.ino
@@ -64,6 +64,7 @@ void connect() {
   while (!client.connect(clientID)) {
     Serial.print(".");
     if (millis() - clTimeout > 5001) {
+      mesh.renewAddress();
       Serial.println();
       return;
     }

--- a/examples/MQTT/mqtt_basic_no_blk/mqtt_basic_no_blk.ino
+++ b/examples/MQTT/mqtt_basic_no_blk/mqtt_basic_no_blk.ino
@@ -48,6 +48,8 @@ IPAddress server(10, 10, 2, 2);   //The ip of the MQTT server
 char clientID[] = { "arduinoClient   " };
 
 void messageReceived(MQTTClient* client, char topic[], char payload[], int length) {
+  (void*)client;
+  (void)length;
   Serial.println("incoming: ");
   Serial.print(topic);
   Serial.print(" - ");

--- a/examples/MQTT/mqtt_basic_no_blk/mqtt_basic_no_blk.ino
+++ b/examples/MQTT/mqtt_basic_no_blk/mqtt_basic_no_blk.ino
@@ -48,7 +48,7 @@ IPAddress server(10, 10, 2, 2);   //The ip of the MQTT server
 char clientID[] = { "arduinoClient   " };
 
 void messageReceived(MQTTClient* client, char topic[], char payload[], int length) {
-  (void*)client;
+  (void)*client;
   (void)length;
   Serial.println("incoming: ");
   Serial.print(topic);


### PR DESCRIPTION
With the recent changes to RF24Mesh involving the `checkConnection()` function now verifying connectivity only with its parent node, additional checks can help maintain connectivity when direct connectivity to the master node is required.

- Update MQTT examples to renew their address if unable to connect to the MQTT server